### PR TITLE
docs: Generate UIManager.cs metadata summary

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -7,7 +7,19 @@
 
 ---
 
-## [Current/Recent] - USS and UXML Styling Cleanup
+## [Current/Recent] - Added Context-Dense Metadata Summary for UIManager
+This update generates a context-dense metadata summary for `UIManager.cs` to assist AI agents in understanding the script's role without reading the full source code.
+
+### 1. Created Script_Descriptions Directory
+* Created `Toris/Assets/Documentation/Script_Descriptions` directory to hold metadata summaries.
+
+### 2. Generated UIManager Metadata Summary
+* Generated `UIManager.md` with structured key-value style fields.
+* Populated fields: Identifier, Architectural Role, Core Logic, Dependency Graph, Data Schema, and Side Effects & Lifecycle.
+
+---
+
+## [Previous] - USS and UXML Styling Cleanup
 This update refactors the UI styling to consistently use global variables and BEM naming conventions across all UI Toolkit assets.
 
 ### 1. Updated Global Styles

--- a/Toris/Assets/Documentation/Script_Descriptions/UIManager.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/UIManager.md
@@ -1,0 +1,24 @@
+Identifier: OutlandHaven.UIToolkit.UIManager : MonoBehaviour
+
+Architectural Role: Singleton Manager / Screen Visibility and Zone Arbitrator
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API:
+  - RegisterView(GameView view, ScreenZone zone): Maps a view to a zone and adds it to the UIDocument layout. Shows HUD by default.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on UIEventsSO (event channel), UIDocument (root element), GameView (registered elements), ScreenZone/ScreenType (Enums).
+- Downstream: Subscribed to by UIEventsSO. Controllers (e.g., PlayerController) call RegisterView to inject views.
+
+Data Schema:
+- UIEventsSO _UIEvents -> Event bus for open/close window requests.
+- bool showHudOnStart -> Configuration toggle.
+- List<GameView> _allViews -> Tracks all managed UI screens.
+- Dictionary<GameView, ScreenZone> _viewZones -> Maps views to their display regions (HUD, Left, Right) for exclusivity logic.
+
+Side Effects & Lifecycle:
+- Awake: Queries UIDocument for visual layout containers ("Layer_HUD", "Left_Zone", "Right_Zone"). Logs error if missing.
+- OnEnable/OnDisable: Subscribes/unsubscribes to global UIEventsSO channels (OnRequestOpen, OnRequestClose, OnRequestCloseAll).
+- OnValidate: Validates _UIEvents serialization.
+- Window Management: Opening a view in a non-HUD zone automatically closes other views in that same zone. Opening Smith or Mage views triggers a side-effect opening of the Inventory view.


### PR DESCRIPTION
Generated a context-dense metadata summary for the `UIManager.cs` script following a structured key-value style format for token efficiency. The summary includes Identifier, Architectural Role, Core Logic, Dependency Graph, Data Schema, and Side Effects & Lifecycle details. The file is saved in the new directory `Toris/Assets/Documentation/Script_Descriptions/UIManager.md`. The changelog was also updated to reflect these additions.

---
*PR created automatically by Jules for task [4516739074950797474](https://jules.google.com/task/4516739074950797474) started by @sourcereris*