### PR TITLE
docs: Add Script Descriptions for UI SubViews

### DIFF
--- a/Toris/Assets/Documentation/Script_Descriptions/SalvageSubView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/SalvageSubView.md
@@ -1,0 +1,27 @@
+Identifier: OutlandHaven.UIToolkit.SalvageSubView : UIView
+
+Architectural Role: Component Logic / Contextual UI SubView
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: Overrides `SetVisualElements()`, `Setup(object)`, `Show()`, `Hide()`, `Dispose()`.
+- Public API:
+  - `Setup(object payload)`: Clears input slot and updates visuals. Payload is ignored.
+  - `Show()`: Binds events and button callbacks.
+  - `Hide()`: Unbinds events and button callbacks.
+  - `Dispose()`: Unbinds remaining events and calls base `Dispose()`.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on `VisualTreeAsset` (slot template), `UIInventoryEventsSO` (event channel), `SalvageManagerSO` (salvage logic/recipes), `InventorySlotView` (slot rendering).
+- Downstream: Instantiated and managed by `SmithView`.
+
+Data Schema:
+- `InventorySlot _currentSlotData`: Proxy data for the item placed in the salvage slot.
+- `InventorySlot _cachedSourceSlot`: Reference to the original slot in the player's inventory to prevent duplicates and handle callbacks.
+- Visual elements and templates (`_slotTemplate`, `_inputSlotContainer`, `_goldYieldField`, `_itemYieldContainer`, etc.) for UI state.
+
+Side Effects & Lifecycle:
+- Instantiates UI Toolkit `TemplateContainer` clones for input and yield slots during `SetVisualElements`.
+- Creates dummy `InventorySlot` and `ItemInstance` objects (heap allocation) when handling proxy drops or item clicks to represent the item without moving it.
+- Subscribes to global `UIInventoryEventsSO` (`OnItemClicked`, `OnItemRightClicked`, `OnRequestSelectForProcessing`) when shown.
+- Emits global events (`OnRequestSalvage`) when "Get Gold" or "Get Item" buttons are clicked.
+- Does not use Unity `Update()` loop. Managed lifecycle via parent view.

--- a/Toris/Assets/Documentation/Script_Descriptions/ShopSubView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/ShopSubView.md
@@ -1,0 +1,28 @@
+Identifier: OutlandHaven.UIToolkit.ShopSubView : UIView
+
+Architectural Role: Component Logic / Contextual UI SubView
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: Overrides `SetVisualElements()`, `Setup(object)`, `Show()`, `Hide()`, `Dispose()`.
+- Public API:
+  - `Setup(object payload)`: Expects `InventoryManager` payload. Binds shop container, recreates slots, and updates gold display.
+  - `Show()`: Binds global events.
+  - `Hide()`: Unbinds global events.
+  - `Dispose()`: Unbinds remaining events and calls base `Dispose()`.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on `InventoryManager` (dynamic shop data), `VisualTreeAsset` (slot template), `UIInventoryEventsSO` (event channels), `GameSessionSO` (player inventory check), `PlayerProgressionAnchorSO` (player gold check).
+- Downstream: Instantiated and managed by `SmithView`. (Potentially other merchant views).
+
+Data Schema:
+- `InventoryManager _shopContainer`: Reference to the active shop's inventory.
+- `PlayerProgressionAnchorSO PlayerAnchor`: Reference to read player gold.
+- `List<InventorySlotView> _slotViews`: Tracks instantiated slot views for lifecycle management and disposal.
+- `const int BULK_BUY_AMOUNT = 10`: Hardcoded bulk transaction amount.
+
+Side Effects & Lifecycle:
+- Clears and rebuilds the `_shopGrid` dynamically during `Setup()` or when `OnShopInventoryUpdated` is fired. Instantiates `TemplateContainer` objects for every slot.
+- Disposes previous `InventorySlotView` instances before rebuilding to prevent memory leaks.
+- Subscribes to global events (`OnCurrencyChanged`, `OnShopInventoryUpdated`, `OnItemRightClicked`) upon `Show()`.
+- Broadcasts transaction requests (`OnRequestBuy`, `OnRequestSell`) via `UIInventoryEventsSO` when items are right-clicked, depending on which container the item belongs to.
+- Does not use Unity `Update()` loop.

--- a/Toris/Assets/Documentation/Script_Descriptions/SmithView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/SmithView.md
@@ -1,0 +1,24 @@
+Identifier: OutlandHaven.UIToolkit.SmithView : GameView
+
+Architectural Role: Singleton Manager / Screen Controller (Mediator)
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: Overrides `ScreenType ID` (returns `ScreenType.Smith`), `SetVisualElements()`, `Setup(object)`, `Hide()`, `Dispose()`.
+- Public API:
+  - `Setup(object payload)`: Expects `InventoryManager` payload for the shop. Forwards to subviews and defaults to showing the Market tab.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on `GameView` base class, multiple `VisualTreeAsset` templates (slot, shop, forge, salvage), `UIEventsSO`, `UIInventoryEventsSO`, `GameSessionSO`, `PlayerProgressionAnchorSO`, `CraftingManagerSO`, `SalvageManagerSO`.
+- Downstream: Instantiated and managed by `UIManager` (or registered dynamically).
+
+Data Schema:
+- `InventoryManager _shopContainer`: Passed down to `ShopSubView`.
+- SubView Instances: `_shopSubView`, `_forgeSubView`, `_salvageSubView`.
+- Visual Elements: Tab buttons (`Smith_Market--Tab`, etc.) and `_middlePanel` container.
+
+Side Effects & Lifecycle:
+- Employs lazy initialization for SubViews (`ShopSubView`, `ForgeSubView`, `SalvageSubView`). They are only instantiated and added to the UI hierarchy when their respective tab is clicked for the first time.
+- Manages subview visibility (`Show()`, `Hide()`) manually in response to tab clicks.
+- Passes dependencies (Managers, SOs, Templates) down to the SubViews upon their initialization.
+- Cascades `Dispose()` calls to all active SubViews when the SmithView is destroyed.
+- Registers standard UI click callbacks for tabs. No Unity `Update()` loop used.


### PR DESCRIPTION
Added markdown files under `Toris/Assets/Documentation/Script_Descriptions` for `SalvageSubView`, `ShopSubView`, and `SmithView`. The formatting strictly follows the requested key-value style with bulleted lists and technical shorthand.

---
*PR created automatically by Jules for task [2591229063911424](https://jules.google.com/task/2591229063911424) started by @sourcereris*