### PR TITLE
docs: add context-dense metadata summaries for UI view scripts

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -165,7 +165,16 @@ This update implements click-to-equip and click-to-unequip functionality for the
 
 ---
 
-## [Current/Recent] - Fixed Dynamic Inventory Growth Bug
+## [Current/Recent] - Documentation Updates
+This update introduces Context-Dense Metadata Summaries for critical UI components to aid AI-assisted development and architectural comprehension.
+
+### 1. Created Script Descriptions
+* Added `PlayerEquipmentView.md` in `Documentation/Script_Descriptions/` detailing its architecture, dependencies, and lifecycle.
+* Added `PlayerInventoryView.md` in `Documentation/Script_Descriptions/` mapping its role as a screen controller, data dependencies, and state management.
+
+---
+
+## [Previous] - Fixed Dynamic Inventory Growth Bug
 This update fixes an issue where the `InventoryManager`'s live slot list would grow beyond the scriptable object's defined capacity when initialized with existing items in the Unity Editor or during gameplay, which caused the UI to break.
 
 ### 1. Updated Initialization Logic

--- a/Toris/Assets/Documentation/Script_Descriptions/PlayerEquipmentView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/PlayerEquipmentView.md
@@ -1,0 +1,29 @@
+Identifier: OutlandHaven.Inventory.PlayerEquipmentView : IDisposable
+
+Architectural Role: Component Logic / View Wrapper
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None.
+- Public API:
+  - Initialize(): Stub for initial setup.
+  - Setup(InventoryManager equipmentInventory): Injects data dependency and refreshes slot visuals.
+  - Show(): Subscribes to inventory events and refreshes visuals.
+  - Hide(): Unsubscribes from inventory events.
+  - Dispose(): Unsubscribes from events to prevent memory leaks during destruction.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Requires UI Toolkit (VisualElement, VisualTreeAsset, TemplateContainer), UIInventoryEventsSO, InventoryManager, and InventorySlotView.
+- Downstream: Instantiated and managed by PlayerInventoryView.
+
+Data Schema:
+- VisualElement _topElement -> Root container for the view.
+- VisualTreeAsset _slotTemplate -> UXML template for equipment slots.
+- UIInventoryEventsSO _uiInventoryEvents -> Global event bus for UI inventory changes.
+- InventoryManager _equipmentInventory -> Injected data source containing equipment stats/slots.
+- bool _eventsBound -> Tracks active event subscription state.
+- VisualElements (_slotHeadContainer, _slotChestContainer, _slotLegsContainer, _slotArmsContainer, _slotWeaponContainer) -> Hardcoded DOM queries mapped to equipment indices.
+
+Side Effects & Lifecycle:
+- Uses manual initialization and manual visibility lifecycle (Setup, Show, Hide, Dispose) rather than MonoBehaviour lifecycle.
+- Instantiates `VisualTreeAsset` into the DOM and allocates new `InventorySlotView` wrappers on the managed heap each time `RefreshSlots` is triggered (on `OnInventoryUpdated` or initial setup).
+- Clears visual containers and applies direct inline styling (`style.display = DisplayStyle.None`) to "count-label" child elements.

--- a/Toris/Assets/Documentation/Script_Descriptions/PlayerInventoryView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/PlayerInventoryView.md
@@ -1,0 +1,31 @@
+Identifier: OutlandHaven.Inventory.PlayerInventoryView : GameView, IDisposable
+
+Architectural Role: Component Logic / UI Screen Controller
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: Inherits from GameView. Overrides ID (ScreenType.Inventory), Initialize, Show, Hide, SetVisualElements, and Setup.
+- Public API:
+  - Initialize(): Sets up base logic and instantiates the nested PlayerEquipmentView.
+  - Setup(object payload): Refreshes the player inventory grid and passes equipment data to the PlayerEquipmentView.
+  - Show(): Binds inventory update events and cascades the Show command to the equipment view.
+  - Hide(): Unbinds inventory update events and cascades the Hide command to the equipment view.
+  - Dispose(): Event cleanup for itself and cascaded Dispose for the equipment view.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Requires GameView, GameSessionSO, UIEventsSO, UIInventoryEventsSO, InventoryManager, PlayerEquipmentView, and InventorySlotView.
+- Downstream: Instantiated and managed by UIManager or screen arbitrators.
+
+Data Schema:
+- ScreenType ID -> Hardcoded to ScreenType.Inventory.
+- VisualTreeAsset _slotTemplate -> Template for individual inventory slots.
+- GameSessionSO _gameSession -> Global source of truth for the primary PlayerInventory data.
+- InventoryManager _equipmentInventory -> Distinct InventoryManager specifically for equipment.
+- UIInventoryEventsSO _uiInventoryEvents -> Local event bus.
+- VisualElement _playerGrid -> Target DOM container for standard inventory items.
+- PlayerEquipmentView _equipmentView -> Encapsulated logic wrapper for the player's equipment UI.
+- bool _eventsBound -> State flag for active event subscriptions.
+
+Side Effects & Lifecycle:
+- Lifecycle follows the standard `GameView` pattern (Initialize -> Setup -> Show/Hide -> Dispose).
+- Instantiates `VisualTreeAsset` clones into the DOM and allocates new `InventorySlotView` wrappers on the managed heap each time `RefreshGrid` is triggered (during Setup or OnInventoryUpdated).
+- Clears the entire visual hierarchy of `_playerGrid` before repopulating on refresh.


### PR DESCRIPTION
Adds Context-Dense Metadata Summaries for `PlayerEquipmentView` and `PlayerInventoryView` using a key-value markdown format to aid AI agents in understanding the scripts' architecture and dependencies. Includes a corresponding CHANGELOG.md entry.

---
*PR created automatically by Jules for task [10063932519509719930](https://jules.google.com/task/10063932519509719930) started by @sourcereris*