### PR TITLE
docs: Add Context-Dense Metadata Summaries for UI scripts

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -7,7 +7,16 @@
 
 ---
 
-## [Current/Recent] - Documentation Updates
+## [Current/Recent] - Script Metadata Summaries Added
+This update adds Context-Dense Metadata Summaries for several UI-related scripts to serve as primary references for AI agents, following a highly structured format.
+
+### 1. Created Script Descriptions
+* Created `ForgeSubView.md`, `GameView.md`, `HUDView.md`, and `MageView.md` inside `Toris/Assets/Documentation/Script_Descriptions/`.
+* Each summary outlines the script's Architectural Role, Core Logic (Abstract/Virtual Methods, Public API), Dependency Graph, Data Schema, and Side Effects & Lifecycle using key-value bulleted formats.
+
+---
+
+## [Previous] - Documentation Updates
 This update addresses missing UI documentation and ensures all project documentation is centralized and correctly formatted according to project conventions.
 
 ### 1. Centralized Event Documentation

--- a/Toris/Assets/Documentation/Script_Descriptions/ForgeSubView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/ForgeSubView.md
@@ -1,0 +1,32 @@
+- **Identifier:** `OutlandHaven.UIToolkit.ForgeSubView : UIView`
+- **Architectural Role:** Component Logic / Processing UI SubView.
+
+- **Core Logic (The 'Contract'):**
+  - **Abstract/Virtual Methods:**
+    - `SetVisualElements()`: Overridden to bind UI elements (`forge-slot-1`, `forge-slot-2`, `forge-result-slot`, `btn-forge-items`) and instantiate slot templates.
+    - `Setup(object payload = null)`: Overridden to clear slots and update the visual result.
+    - `Show()`: Overridden to subscribe to inventory events and button clicks.
+    - `Hide()`: Overridden to unsubscribe from inventory events and button clicks.
+    - `Dispose()`: Overridden to clean up event subscriptions to prevent memory leaks.
+  - **Public API:**
+    - `ForgeSubView(...)`: Constructor for dependency injection (`VisualTreeAsset`, `UIInventoryEventsSO`, `CraftingManagerSO`).
+
+- **Dependency Graph (Crucial for Scaling):**
+  - **Upstream:**
+    - Requires `OutlandHaven.UIToolkit.UIView` (Base Class).
+    - Requires `UnityEngine.UIElements.VisualTreeAsset` (Slot template).
+    - Requires `OutlandHaven.Inventory.UIInventoryEventsSO` (Event channel for item interactions).
+    - Requires `OutlandHaven.Inventory.CraftingManagerSO` (Logic arbitrator for recipes).
+  - **Downstream:**
+    - Handled/instantiated by parent views containing a forge UI.
+
+- **Data Schema:**
+  - `_slotTemplate` (VisualTreeAsset): Template for generating UI inventory slots.
+  - `_uiInventoryEvents` (UIInventoryEventsSO): Reference to global UI inventory events.
+  - `_craftingManager` (CraftingManagerSO): Reference to the crafting manager logic.
+  - `_currentSlot1Data`, `_currentSlot2Data` (InventorySlot): Proxy data representing items selected for forging.
+  - `_cachedSlot1`, `_cachedSlot2` (InventorySlot): Original inventory slots of the selected items.
+
+- **Side Effects & Lifecycle:**
+  - **Lifecycle:** Standard `UIView` manual lifecycle. Instantiates `InventorySlotView` wrappers dynamically during `SetVisualElements()`. Subscribes to events in `Show()` and unsubscribes in `Hide()`/`Dispose()`.
+  - **Side Effects:** Evaluates crafting recipes via `_craftingManager`. Triggers `OnRequestForge` event via `_uiInventoryEvents`. Implements 'Right-Click to Auto-Fill' and ghost slots (proxy data) instead of directly mutating the player's actual inventory until confirmed. Allocates proxy `InventorySlot` and `ItemInstance` objects on the managed heap when assigning items.

--- a/Toris/Assets/Documentation/Script_Descriptions/GameView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/GameView.md
@@ -1,0 +1,24 @@
+- **Identifier:** `OutlandHaven.UIToolkit.GameView : UIView`
+- **Architectural Role:** Abstract Blueprint / Base Class for distinct full-screen UI views managed by `UIManager`.
+
+- **Core Logic (The 'Contract'):**
+  - **Abstract/Virtual Methods:**
+    - `ID` (Abstract Property): Must be implemented by children to define their `ScreenType` identifier.
+    - `Show()`: Overridden to invoke `UIEvents.OnScreenOpen` upon displaying the view, alongside base behavior.
+  - **Public API:**
+    - `GameView(...)`: Constructor for base element binding and `UIEventsSO` dependency injection.
+
+- **Dependency Graph (Crucial for Scaling):**
+  - **Upstream:**
+    - Requires `OutlandHaven.UIToolkit.UIView` (Base Class).
+    - Requires `OutlandHaven.UIToolkit.UIEventsSO` (Event channel for global UI screen transitions).
+    - Requires `OutlandHaven.UIToolkit.ScreenType` (Enum for screen identification).
+  - **Downstream:**
+    - Inherited by concrete screen controllers (e.g., `HUDView`, `MageView`).
+
+- **Data Schema:**
+  - `UIEvents` (protected UIEventsSO): Holds the reference to broadcast screen state changes.
+
+- **Side Effects & Lifecycle:**
+  - **Lifecycle:** Derives from manual `UIView` lifecycle.
+  - **Side Effects:** Triggers global `OnScreenOpen` event when shown, effectively notifying `UIManager` and other listeners of screen context changes.

--- a/Toris/Assets/Documentation/Script_Descriptions/HUDView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/HUDView.md
@@ -1,0 +1,31 @@
+- **Identifier:** `OutlandHaven.UIToolkit.HUDView : GameView`
+- **Architectural Role:** Component Logic / Presentation Layer for Player HUD.
+
+- **Core Logic (The 'Contract'):**
+  - **Abstract/Virtual Methods:**
+    - `ID` (Property): Implements `ScreenType.HUD`.
+    - `Setup(object payload)`: Overridden to instantiate dynamic menu buttons and push initial data from the `PlayerHUDBridge` exactly once (`_isSetup` flag).
+    - `SetVisualElements()`: Overridden to bind UI progress bars, labels, and menu containers.
+    - `RegisterButtonCallbacks()`: Overridden to hook up the main menu toggle button.
+    - `Show()`: Overridden to subscribe to `PlayerHUDBridge` stat events and trigger initial state push.
+    - `Hide()`: Overridden to unsubscribe from `PlayerHUDBridge` events.
+  - **Public API:**
+    - `HUDView(...)`: Constructor for dependency injection (`PlayerHUDBridge`, `UIEventsSO`, button `VisualTreeAsset`).
+
+- **Dependency Graph (Crucial for Scaling):**
+  - **Upstream:**
+    - Requires `OutlandHaven.UIToolkit.GameView` (Base Class).
+    - Requires `OutlandHaven.UIToolkit.PlayerHUDBridge` (Data source and event channel for player stats).
+    - Requires `UnityEngine.UIElements.VisualTreeAsset` (Menu button template).
+  - **Downstream:**
+    - Handled by global `UIManager`.
+
+- **Data Schema:**
+  - `_playerHudBridge` (PlayerHUDBridge): Data connection for health, stamina, XP, gold, and level.
+  - `_buttonTemplate` (VisualTreeAsset): Template for generating quick-access menu buttons.
+  - `PROGRESS_BAR_MAX` (const float = 100f): Scale factor for UI Toolkit progress bars.
+  - `_isSetup` (bool): Flag preventing duplicate initialization.
+
+- **Side Effects & Lifecycle:**
+  - **Lifecycle:** Standard manual initialization lifecycle driven by `UIManager`.
+  - **Side Effects:** Dynamically instantiates multiple UI elements into `_optionsContainer` during `Setup()`. Toggles inline UI display styles (`Flex`/`None`) upon button clicks. Modifies progress bar `value` attributes based on normalized bridging data.

--- a/Toris/Assets/Documentation/Script_Descriptions/MageView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/MageView.md
@@ -1,0 +1,30 @@
+- **Identifier:** `OutlandHaven.UIToolkit.MageView : GameView`
+- **Architectural Role:** Context Wrapper / Aggregation View for Mage NPC interactions.
+
+- **Core Logic (The 'Contract'):**
+  - **Abstract/Virtual Methods:**
+    - `ID` (Property): Implements `ScreenType.Mage`.
+    - `SetVisualElements()`: Overridden to bind the middle panel container and market tab button.
+    - `Setup(object payload)`: Overridden to cast payload into dynamic `InventoryManager` (shop container) and initialize the default active tab.
+    - `Hide()`: Overridden to cascade `Hide()` calls to nested sub-views.
+    - `Dispose()`: Overridden to cascade `Dispose()` calls to nested sub-views.
+  - **Public API:**
+    - `MageView(...)`: Constructor for heavy dependency injection (Templates, Events, Session, ShopManager).
+
+- **Dependency Graph (Crucial for Scaling):**
+  - **Upstream:**
+    - Requires `OutlandHaven.UIToolkit.GameView` (Base Class).
+    - Requires `OutlandHaven.UIToolkit.ShopSubView` (Nested logic view).
+    - Requires `OutlandHaven.Inventory.InventoryManager` (Data container for dynamic shop inventory).
+    - Requires `UnityEngine.UIElements.VisualTreeAsset` (Templates for slot and shop structure).
+  - **Downstream:**
+    - Handled by global `UIManager` via specific NPC interaction events.
+
+- **Data Schema:**
+  - `_slotTemplate`, `_shopTemplate` (VisualTreeAsset): UI structure templates.
+  - `_shopContainer` (InventoryManager): Caches the dynamic payload representing the NPC's inventory state.
+  - `_shopSubView` (ShopSubView): Managed instance of the specialized shop logic controller.
+
+- **Side Effects & Lifecycle:**
+  - **Lifecycle:** Standard manual initialization lifecycle driven by `UIManager`. Sub-view lifecycle (`Initialize`, `Setup`, `Show`, `Hide`, `Dispose`) is explicitly orchestrated within this class.
+  - **Side Effects:** Employs 'Lazy Initialization'—instantiating and binding the `ShopSubView` UI elements into `_middlePanel` only when `ShowMarketTab()` is first requested. Binds a click listener to the `Mage_Market--Tab` UI element.


### PR DESCRIPTION
Adds Context-Dense Metadata Summaries for UI scripts to serve as primary references for AI agents. The summaries follow a highly-structured, key-value bulleted format to document the scripts' architectural role, core logic, dependencies, and lifecycle without conversational language.

---
*PR created automatically by Jules for task [3647247548688634450](https://jules.google.com/task/3647247548688634450) started by @sourcereris*