### PR TITLE
📝 [docs] Add metadata summaries for UIEventsSO and ScreenTypes

### DIFF
--- a/Toris/Assets/Documentation/Script_Descriptions/ScreenTypes.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/ScreenTypes.md
@@ -1,0 +1,19 @@
+Identifier: OutlandHaven.UIToolkit.ScreenType / ScreenZone / UIEvents : Enum / Static Class
+
+Architectural Role: Data Container / Decoupled Event
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API: None (Data only, static event delegate `OnScreenOpen`)
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: None
+- Downstream: Referenced by UIManager, UIEventsSO, and system managers managing UI screen logic and exclusivity.
+
+Data Schema:
+- ScreenType (Enum) -> Logical window identifiers (None, HUD, Inventory, CharacterSheet, PauseMenu, Smith, Mage).
+- ScreenZone (Enum) -> UI layout regions for window exclusivity (HUD, Left, Right, Modal).
+- UIEvents.OnScreenOpen (Action<ScreenType>) -> Static event broadcast when a screen finishes opening.
+
+Side Effects & Lifecycle:
+- Passive enums and static delegate. No instantiation or MonoBehaviour lifecycle methods.

--- a/Toris/Assets/Documentation/Script_Descriptions/UIEventsSO.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/UIEventsSO.md
@@ -1,0 +1,20 @@
+Identifier: OutlandHaven.UIToolkit.UIEventsSO : ScriptableObject
+
+Architectural Role: Decoupled Event Channel / Event Bus
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API: None (Exposes public UnityAction delegates for invocation/subscription).
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on ScreenType (Enum).
+- Downstream: Subscribed to by UIManager and UI Controllers. Invoked by UI interactions (e.g., buttons, hotkeys) or system logic.
+
+Data Schema:
+- UnityAction<ScreenType, object> OnRequestOpen -> Requests opening a specific screen, optionally passing a data payload (e.g., InventoryManager).
+- UnityAction<ScreenType> OnRequestClose -> Requests closing a specific screen.
+- UnityAction OnRequestCloseAll -> Requests closing all non-HUD screens.
+- UnityAction<ScreenType> OnScreenOpen -> Broadcast when a screen successfully opens (duplicates static `UIEvents.OnScreenOpen`).
+
+Side Effects & Lifecycle:
+- Asset-based lifecycle. Delegates are bound/unbound at runtime by observing MonoBehaviours (e.g., UIManager). No internal execution logic or state mutations.


### PR DESCRIPTION
Adds script descriptions in the specified `Script_Descriptions` folder for `ScreenTypes.cs` and `UIEventsSO.cs` using the strict key-value format for AI agents without using conversational language.

---
*PR created automatically by Jules for task [7908190875991403176](https://jules.google.com/task/7908190875991403176) started by @sourcereris*