### PR TITLE
📝 Add Script Metadata Summaries for UI Controllers

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -7,7 +7,20 @@
 
 ---
 
-## [Current/Recent] - Documentation Updates
+## [Current/Recent] - Added Script Metadata Summaries
+This update adds structured context-dense metadata summaries for UI Toolkit screen controllers to aid AI agents and developers in understanding the codebase architecture.
+
+### 1. Created Metadata Summaries
+* Generated context-dense key-value documentation in `Toris/Assets/Documentation/Script_Descriptions/` for:
+  * `HudScreenController.md`
+  * `InventoryScreenController.md`
+  * `MageScreenController.md`
+  * `MainMenuScreenController.md`
+  * `SmithScreenController.md`
+
+---
+
+## [Previous] - Documentation Updates
 This update addresses missing UI documentation and ensures all project documentation is centralized and correctly formatted according to project conventions.
 
 ### 1. Centralized Event Documentation

--- a/Toris/Assets/Documentation/Script_Descriptions/HudScreenController.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/HudScreenController.md
@@ -1,0 +1,24 @@
+Identifier: OutlandHaven.UIToolkit.HudScreenController : MonoBehaviour
+
+Architectural Role: Component Logic
+
+Core Logic:
+- Abstract/Virtual Methods: None
+- Public API: None
+
+Dependency Graph:
+- Upstream: Depends on UIManager, PlayerHUDBridge, VisualTreeAsset (UI templates), GameSessionSO, UIEventsSO, PlayerProgressionAnchorSO, PlayerStatsAnchorSO, HUDView.
+- Downstream: None.
+
+Data Schema:
+- VisualTreeAsset _hudMainTemplate -> Main HUD UI markup template.
+- VisualTreeAsset _buttonTemplate -> Reusable UI button template.
+- GameSessionSO _gameSession -> Reference to global game session state.
+- UIEventsSO _uiEvents -> Global UI event channel.
+- PlayerProgressionAnchorSO _playerAnchor -> Player progression data anchor.
+- PlayerStatsAnchorSO _playerStatsAnchor -> Player stats data anchor.
+
+Side Effects & Lifecycle:
+- Awake: Queries the scene for UIManager and PlayerHUDBridge singletons.
+- OnEnable/OnValidate: Editor and runtime validation of required references.
+- Start: Instantiates _hudMainTemplate, allocates and initializes a new HUDView instance, and registers the view to UIManager on ScreenZone.HUD.

--- a/Toris/Assets/Documentation/Script_Descriptions/InventoryScreenController.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/InventoryScreenController.md
@@ -1,0 +1,24 @@
+Identifier: OutlandHaven.Inventory.InventoryScreenController : MonoBehaviour
+
+Architectural Role: Component Logic
+
+Core Logic:
+- Abstract/Virtual Methods: None
+- Public API: None
+
+Dependency Graph:
+- Upstream: Depends on UIManager, VisualTreeAsset (UI templates), GameSessionSO, UIEventsSO, UIInventoryEventsSO, InventoryManager (equipment), PlayerInventoryView.
+- Downstream: None.
+
+Data Schema:
+- VisualTreeAsset _inventoryMainTemplate -> Main inventory UI markup template.
+- VisualTreeAsset _slotTemplate -> Reusable item slot template.
+- GameSessionSO _gameSession -> Reference to global game session state.
+- UIEventsSO _uiEvents -> Global UI event channel.
+- UIInventoryEventsSO _uiInventoryEvents -> Inventory-specific UI event channel.
+- InventoryManager _equipmentInventory -> Configured equipment inventory container.
+
+Side Effects & Lifecycle:
+- Awake: Queries the scene for UIManager singleton.
+- OnEnable/OnValidate: Editor and runtime validation of required references.
+- Start: Instantiates _inventoryMainTemplate, mutates flexGrow style, allocates and initializes a new PlayerInventoryView instance, and registers the view to UIManager on ScreenZone.Right.

--- a/Toris/Assets/Documentation/Script_Descriptions/MageScreenController.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/MageScreenController.md
@@ -1,0 +1,26 @@
+Identifier: OutlandHaven.UIToolkit.MageScreenController : MonoBehaviour
+
+Architectural Role: Component Logic
+
+Core Logic:
+- Abstract/Virtual Methods: None
+- Public API: None
+
+Dependency Graph:
+- Upstream: Depends on UIManager, VisualTreeAsset (UI templates), UIEventsSO, UIInventoryEventsSO, GameSessionSO, ShopManagerSO, MageView.
+- Downstream: None.
+
+Data Schema:
+- VisualTreeAsset _mageMainTemplate -> Mage screen root UI template.
+- VisualTreeAsset _slotTemplate -> Reusable item slot template.
+- VisualTreeAsset _shopTemplate -> Shop sub-view UI template.
+- UIEventsSO _uiEvents -> Global UI event channel.
+- UIInventoryEventsSO _uiInventoryEvents -> Inventory-specific UI event channel.
+- GameSessionSO _gameSession -> Reference to global game session state.
+- ShopManagerSO _shopManagerSO -> Shop transaction and logic manager.
+
+Side Effects & Lifecycle:
+- Awake: Queries the scene for UIManager singleton, and initializes _shopManagerSO.
+- OnEnable/OnDisable: Subscribes/unsubscribes HandleRequestOpen to _uiEvents.OnRequestOpen and validates references.
+- Start: Instantiates _mageMainTemplate, allocates and initializes a new MageView instance, and registers the view to UIManager on ScreenZone.Left.
+- Event Callbacks: HandleRequestOpen validates payload as an InventoryManager for ScreenType.Mage, and dynamically injects the target NPC inventory into _shopManagerSO.CurrentShopInventory.

--- a/Toris/Assets/Documentation/Script_Descriptions/MainMenuScreenController.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/MainMenuScreenController.md
@@ -1,0 +1,22 @@
+Identifier: OutlandHaven.UIToolkit.MainMenuScreenController : MonoBehaviour
+
+Architectural Role: Component Logic
+
+Core Logic:
+- Abstract/Virtual Methods: None
+- Public API:
+  - QuitGame(): Stops Unity Editor play mode or quits the built application runtime.
+
+Dependency Graph:
+- Upstream: Depends on UIDocument (UI Toolkit element mapping), GameSessionSO, UnityEngine.SceneManagement.SceneManager.
+- Downstream: Handled natively by UI Toolkit click events.
+
+Data Schema:
+- GameSessionSO gameSession -> Session context data for save/load operations.
+- string VillageSceneName -> Target scene name to load when starting a new game (default: "MainArea").
+- UIDocument _doc -> Reference to the attached main menu UI document.
+
+Side Effects & Lifecycle:
+- OnEnable: Queries UIDocument root for buttons (btn-start-game, btn-quit-game) and subscribes to their clicked events.
+- OnDisable: Unsubscribes from button clicked events to prevent memory leaks.
+- Event Callbacks: Triggering btn-start-game calls SceneManager.LoadScene to transition game context.

--- a/Toris/Assets/Documentation/Script_Descriptions/SmithScreenController.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/SmithScreenController.md
@@ -1,0 +1,27 @@
+Identifier: OutlandHaven.UIToolkit.SmithScreenController : MonoBehaviour
+
+Architectural Role: Component Logic
+
+Core Logic:
+- Abstract/Virtual Methods: None
+- Public API: None
+
+Dependency Graph:
+- Upstream: Depends on UIManager, VisualTreeAsset (UI templates), UIEventsSO, UIInventoryEventsSO, GameSessionSO, PlayerProgressionAnchorSO, ShopManagerSO, CraftingManagerSO, SalvageManagerSO, SmithView.
+- Downstream: None.
+
+Data Schema:
+- VisualTreeAsset _smithMainTemplate, _slotTemplate, _shopTemplate, _forgeTemplate, _salvageTemplate -> View hierarchy UI templates.
+- UIEventsSO _uiEvents -> Global UI event channel.
+- UIInventoryEventsSO _uiInventoryEvents -> Inventory-specific UI event channel.
+- GameSessionSO _gameSession -> Reference to global game session state.
+- PlayerProgressionAnchorSO _playerAnchor -> Player progression data anchor.
+- ShopManagerSO _shopManagerSO -> Shop transaction manager.
+- CraftingManagerSO _craftingManagerSO -> Forging logic manager.
+- SalvageManagerSO _salvageManagerSO -> Salvage processing manager.
+
+Side Effects & Lifecycle:
+- Awake: Queries the scene for UIManager singleton, and initializes all linked logic managers (_shopManagerSO, _craftingManagerSO, _salvageManagerSO).
+- OnEnable/OnDisable: Subscribes/unsubscribes HandleRequestOpen to _uiEvents.OnRequestOpen and validates references.
+- Start: Instantiates _smithMainTemplate, allocates and initializes a new SmithView instance, and registers the view to UIManager on ScreenZone.Left.
+- Event Callbacks: HandleRequestOpen validates payload as an InventoryManager for ScreenType.Smith, and dynamically injects the target NPC inventory into _shopManagerSO.CurrentShopInventory.


### PR DESCRIPTION
Adds structured context-dense metadata summaries for UI Toolkit screen controllers to aid AI agents and developers in understanding the codebase architecture.

### 1. Created Metadata Summaries
* Generated context-dense key-value documentation in `Toris/Assets/Documentation/Script_Descriptions/` for:
  * `HudScreenController.md`
  * `InventoryScreenController.md`
  * `MageScreenController.md`
  * `MainMenuScreenController.md`
  * `SmithScreenController.md`

### 2. Updated Changelog
* Added an entry to `CHANGELOG.md` detailing the addition of the new metadata summary files.

---
*PR created automatically by Jules for task [12936065134639109341](https://jules.google.com/task/12936065134639109341) started by @sourcereris*