### PR TITLE
doc: add context-dense metadata summaries for inventory scripts

### DIFF
--- a/Toris/Assets/Documentation/Script_Descriptions/InventorySlot.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/InventorySlot.md
@@ -1,0 +1,25 @@
+Identifier: OutlandHaven.Inventory.InventorySlot
+
+Architectural Role: Data Container
+
+Core Logic:
+* Abstract/Virtual Methods: None
+* Public API:
+  * `Clear()`: Nullifies `HeldItem` and sets `Count` to 0.
+  * `SetItem(ItemInstance newItem, int amount)`: Sets `HeldItem` and `Count`.
+  * `IncreaseCount(int amount)`: Increments `Count`.
+  * `DecreaseCount(int amount)`: Decrements `Count`, calls `Clear()` if `Count` <= 0.
+
+Dependency Graph:
+* Upstream: Requires `ItemInstance`.
+* Downstream: Consumed by `InventoryManager`, `InventorySlotView`.
+
+Data Schema:
+* `ItemInstance HeldItem`: Serialized reference to the runtime item state occupying the slot.
+* `int Count`: Serialized integer representing the stack quantity.
+* `bool IsEmpty` (Property): Evaluates if `HeldItem` is null or its `BaseItem` is null.
+
+Side Effects & Lifecycle:
+* Initialization: Manual initialization via constructor.
+* Allocations: Instantiates a new empty `ItemInstance` upon construction.
+* Lifecycle: No Unity lifecycle methods (pure C# object).

--- a/Toris/Assets/Documentation/Script_Descriptions/InventorySlotView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/InventorySlotView.md
@@ -1,0 +1,28 @@
+Identifier: OutlandHaven.Inventory.InventorySlotView : IDisposable (Implicit via Dispose method)
+
+Architectural Role: Component Logic (UI Controller)
+
+Core Logic:
+* Abstract/Virtual Methods: None
+* Public API:
+  * `Update(InventorySlot slotData)`: Binds data, updates visual state (icon, quantity), and sets user data for drag/drop.
+  * `Dispose()`: Unregisters pointer callbacks to prevent memory leaks.
+
+Dependency Graph:
+* Upstream: Requires `UnityEngine.UIElements`, `InventorySlot`, `InventoryManager`, `UIInventoryEventsSO`, `UIDragManager`.
+* Downstream: Managed by Parent Views (e.g., `PlayerInventoryView`, `PlayerEquipmentView`).
+
+Data Schema:
+* `VisualElement _root`: Reference to the root slot container element.
+* `Image _icon`: Reference to the item icon element.
+* `Label _qtyLabel`: Reference to the item quantity label.
+* `InventorySlot _slotData`: Cached reference to the bound slot data.
+* `InventoryManager _owningContainer`: Reference to the container managing the slot.
+* `UIInventoryEventsSO _uiInventoryEvents`: Reference to the event channel for UI interactions.
+* `bool _isDragging`: Tracks active drag state.
+* `Vector2 _dragStartPosition`: Tracks the pointer position where the click originated.
+
+Side Effects & Lifecycle:
+* Initialization: Manual initialization via constructor (binds UI elements and registers callbacks).
+* Allocations: Instantiates `SlotDropData` during `Update` if not using a proxy ID.
+* Lifecycle: Subscribes to `PointerDownEvent`, `PointerMoveEvent`, `PointerUpEvent` on the root element. Triggers external events on `UIInventoryEventsSO`. Must be explicitly disposed via `Dispose()`. Modifies `pickingMode` of UI elements.

--- a/Toris/Assets/Documentation/Script_Descriptions/ItemInstance.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/ItemInstance.md
@@ -1,0 +1,26 @@
+Identifier: OutlandHaven.Inventory.ItemInstance
+
+Architectural Role: Data Container (Runtime State Wrapper)
+
+Core Logic:
+* Abstract/Virtual Methods: None
+* Public API:
+  * `NotifyStateChanged()`: Invokes `OnStateChanged` action.
+  * `GetState<T>()`: Retrieves a specific typed state at runtime.
+  * `IsStackableWith(ItemInstance other)`: Checks if this instance can merge with another (requires matching blueprint and identical state composition).
+  * `Clone()`: Creates a deep copy of the item instance and its states with a new `InstanceID`.
+
+Dependency Graph:
+* Upstream: Requires `InventoryItemSO`, `ItemComponentState`.
+* Downstream: Consumed by `InventorySlot`, Inventory Managers, Equipment System.
+
+Data Schema:
+* `string InstanceID`: Unique identifier for saving/loading.
+* `InventoryItemSO BaseItem`: Reference to the base item blueprint.
+* `List<ItemComponentState> States`: Serialized list of runtime component states (e.g., Durability, Consumable).
+* `Action<ItemInstance> OnStateChanged`: Event triggered on state mutation.
+
+Side Effects & Lifecycle:
+* Initialization: Manual initialization via constructors. The blueprint constructor allocates and adds initial states based on `BaseItem.Components`.
+* Allocations: Instantiates a Guid string on creation. Instantiates a new state list upon cloning. Allocates specific state instances when initialized from a blueprint.
+* Lifecycle: No Unity lifecycle methods (pure C# object). Relies on explicit event invocation (`NotifyStateChanged`).

--- a/Toris/Assets/Documentation/Script_Descriptions/WorldContainer.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/WorldContainer.md
@@ -1,0 +1,25 @@
+Identifier: OutlandHaven.UIToolkit.WorldContainer : MonoBehaviour
+
+Architectural Role: Component Logic (World Interaction)
+
+Core Logic:
+* Abstract/Virtual Methods: None
+* Public API: None (All methods are private lifecycle or interaction handlers).
+
+Dependency Graph:
+* Upstream: Requires `InventoryManager`, `UIEventsSO`, `Collider2D` (attached to object), "Player" tag on interacting object.
+* Downstream: Interacts with UI Managers (via `UIEventsSO`).
+
+Data Schema:
+* `InventoryManager _containerData`: Serialized reference to the container's inventory data component.
+* `UIEventsSO _uiEvents`: Serialized reference to the global UI event channel.
+* `KeyCode _interactKey`: Serialized keybind for interaction (Default: F).
+* `bool _playerInRange`: Tracks if the player is within the interaction trigger.
+
+Side Effects & Lifecycle:
+* Initialization: Uses `Awake` to self-assign `_containerData` if null. Uses `OnValidate` to check for missing dependencies in the Editor.
+* Allocations: No significant per-frame allocations.
+* Lifecycle:
+  * `Update`: Listens for `_interactKey` input when `_playerInRange` is true. Calls `OpenContainer()` which fires `OnRequestOpen`.
+  * `OnTriggerEnter2D`: Sets `_playerInRange` true if the colliding object has the "Player" tag.
+  * `OnTriggerExit2D`: Sets `_playerInRange` false and fires `OnRequestClose` if the colliding object has the "Player" tag.


### PR DESCRIPTION
Added structured Markdown summaries containing Context-Dense Metadata for `InventorySlot.cs`, `InventorySlotView.cs`, `ItemInstance.cs`, and `WorldContainer.cs` within `Toris/Assets/Documentation/Script_Descriptions/`. The document summaries follow a strictly formatted schema to support large-scale AI project navigation.

---
*PR created automatically by Jules for task [8759956577077367149](https://jules.google.com/task/8759956577077367149) started by @sourcereris*