### PR TITLE
docs: Add context-dense metadata summaries for UI and Item scripts

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -165,7 +165,16 @@ This update implements click-to-equip and click-to-unequip functionality for the
 
 ---
 
-## [Current/Recent] - Fixed Dynamic Inventory Growth Bug
+## [Current/Recent] - Script Metadata Documentation
+This update adds Context-Dense Metadata Summaries for several script files as part of expanding the AI assistant documentation context.
+
+### 1. Created Script Descriptions
+* Added `SalvageManagerSO.md`, `SalvageRecipeSO.md`, `ShopManagerSO.md`, `UpgradeSalvageManagerSO.md`, and `ItemTestDebugger.md` to `Toris/Assets/Documentation/Script_Descriptions/`.
+* Ensured summaries are highly token-efficient and use a structured key-value format without conversational language.
+
+---
+
+## [Previous] - Fixed Dynamic Inventory Growth Bug
 This update fixes an issue where the `InventoryManager`'s live slot list would grow beyond the scriptable object's defined capacity when initialized with existing items in the Unity Editor or during gameplay, which caused the UI to break.
 
 ### 1. Updated Initialization Logic

--- a/Toris/Assets/Documentation/Script_Descriptions/ItemTestDebugger.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/ItemTestDebugger.md
@@ -1,0 +1,20 @@
+Identifier: OutlandHaven.Inventory.EvolvingWeaponDebugger : MonoBehaviour
+
+Architectural Role: Component Logic / Temporary Testing Script
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API: None
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on InventoryItemSO, EvolvingComponent, EvolvingState, ItemInstance.
+- Downstream: None (Stand-alone testing script).
+
+Data Schema:
+- InventoryItemSO CursedDaggerBlueprint -> Blueprint used to instantiate the test item.
+
+Side Effects & Lifecycle:
+- Uses Unity Start() lifecycle method.
+- Instantiates a new ItemInstance on the managed heap.
+- Simulates state changes (adding kills) to test the evolving weapon logic.
+- Logs output to the Unity console.

--- a/Toris/Assets/Documentation/Script_Descriptions/SalvageManagerSO.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/SalvageManagerSO.md
@@ -1,0 +1,25 @@
+Identifier: OutlandHaven.UIToolkit.SalvageManagerSO : ScriptableObject
+
+Architectural Role: Singleton Manager / Event Arbitrator
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API:
+  - Initialize(): Subscribes to InventoryEvents.OnRequestSalvage.
+  - Cleanup(): Unsubscribes from InventoryEvents.OnRequestSalvage.
+  - CanSalvage(InventoryItemSO itemType): Returns true if player inventory contains salvageable instances of the item type.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on GameSessionSO, PlayerProgressionAnchorSO, UIInventoryEventsSO, CraftingRegistrySO, SalvageRecipeSO.
+- Downstream: Subscribed to by UI/Game state initializers.
+
+Data Schema:
+- GameSessionSO SessionData -> Global session state referencing player inventory.
+- PlayerProgressionAnchorSO PlayerAnchor -> Reference to active player progression/gold.
+- UIInventoryEventsSO InventoryEvents -> Event channel for salvage requests.
+- CraftingRegistrySO Registry -> Contains mappings from item types to SalvageRecipeSOs.
+
+Side Effects & Lifecycle:
+- Manual initialization via Initialize() and Cleanup().
+- HandleRequestSalvage modifies PlayerInventory (removes item, adds materials) and PlayerAnchor (adds gold).
+- Invokes OnCurrencyChanged and OnInventoryUpdated events.

--- a/Toris/Assets/Documentation/Script_Descriptions/SalvageRecipeSO.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/SalvageRecipeSO.md
@@ -1,0 +1,19 @@
+Identifier: OutlandHaven.UIToolkit.SalvageRecipeSO : ScriptableObject
+
+Architectural Role: Data Container / Blueprint
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API: None
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on InventoryItemSO (target item and yields), CraftingMaterialRequirement.
+- Downstream: Read by SalvageManagerSO, UpgradeSalvageManagerSO, and CraftingRegistrySO.
+
+Data Schema:
+- InventoryItemSO TargetItem -> The input item to be salvaged.
+- int GoldYield -> Base gold output from salvaging.
+- List<CraftingMaterialRequirement> MaterialYields -> List of materials (and quantities) yielded from salvaging.
+
+Side Effects & Lifecycle:
+- Static data container. No runtime side effects or dynamic instantiation.

--- a/Toris/Assets/Documentation/Script_Descriptions/ShopManagerSO.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/ShopManagerSO.md
@@ -1,0 +1,27 @@
+Identifier: OutlandHaven.UIToolkit.ShopManagerSO : ScriptableObject
+
+Architectural Role: Singleton Manager / Event Arbitrator
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API:
+  - Initialize(): Subscribes to UIInventoryEventsSO (buy/sell) and UIEventsSO (screen open).
+  - Cleanup(): Unsubscribes from events.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on GameSessionSO, PlayerProgressionAnchorSO, UIInventoryEventsSO, UIEventsSO, InventoryManager (NPC).
+- Downstream: Subscribed to by UI/Game state initializers.
+
+Data Schema:
+- GameSessionSO SessionData -> Global session state referencing player inventory.
+- PlayerProgressionAnchorSO PlayerAnchor -> Reference to active player progression/gold.
+- UIInventoryEventsSO InventoryEvents -> Event channel for buy/sell requests.
+- UIEventsSO UIEvents -> Event channel for tracking active shop views.
+- InventoryManager CurrentShopInventory -> Non-serialized dynamic reference to the active vendor's inventory.
+
+Side Effects & Lifecycle:
+- Manual initialization via Initialize() and Cleanup().
+- HandleRequestOpen caches the NPC's InventoryManager when a Smith or Mage screen opens.
+- HandleRequestBuy modifies PlayerInventory, CurrentShopInventory, and PlayerAnchor (deducts gold).
+- HandleRequestSell modifies PlayerInventory, CurrentShopInventory, and PlayerAnchor (adds gold).
+- Invokes OnCurrencyChanged, OnShopInventoryUpdated, and OnInventoryUpdated events.

--- a/Toris/Assets/Documentation/Script_Descriptions/UpgradeSalvageManagerSO.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/UpgradeSalvageManagerSO.md
@@ -1,0 +1,25 @@
+Identifier: OutlandHaven.UIToolkit.UpgradeSalvageManagerSO : ScriptableObject
+
+Architectural Role: Singleton Manager / Component Logic
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API:
+  - CalculateUpgradeCost(ItemInstance itemInstance): Returns integer gold cost based on item's current upgrade level.
+  - TryUpgradeItem(InventorySlot slot): Validates conditions, deducts gold, increments item level, and notifies state change. Returns boolean success.
+  - TrySalvageItem(InventoryManager container, ItemInstance itemInstanceToSalvage): Removes item, yields gold (and potentially materials), returns boolean success.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on GameSessionSO, PlayerProgressionAnchorSO, CraftingRegistrySO, SalvageRecipeSO, UpgradeableComponent, UpgradeableState.
+- Downstream: Called by processing UI views/presenters (e.g., Forge/Salvage screens).
+
+Data Schema:
+- GameSessionSO SessionData -> Global session state.
+- PlayerProgressionAnchorSO PlayerAnchor -> Reference to active player progression/gold.
+- CraftingRegistrySO Registry -> Reference to recipes for salvage yields.
+- int UpgradeBaseGoldCost -> Base multiplier for calculating upgrade costs.
+
+Side Effects & Lifecycle:
+- Executes on demand (no Update loop).
+- TryUpgradeItem mutates ItemInstance state (increments CurrentLevel) and deducts gold via PlayerAnchor.
+- TrySalvageItem mutates an InventoryManager (removes item) and adds gold via PlayerAnchor.


### PR DESCRIPTION
Added structured script metadata markdown files into `Toris/Assets/Documentation/Script_Descriptions/`. This acts as an API and dependency reference for other AI tools without needing to read the raw source files. The documentation conforms strictly to the specified key-value constraints and ignores conversational tones.

---
*PR created automatically by Jules for task [13785545853547982804](https://jules.google.com/task/13785545853547982804) started by @sourcereris*