### PR TITLE
docs: Add context-dense metadata summaries for C# scripts

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -7,7 +7,17 @@
 
 ---
 
-## [Current/Recent] - Documentation Updates
+## [Current/Recent] - Script Metadata Documentation
+This update adds Context-Dense Metadata Summaries for several script files to act as primary references for AI agents.
+
+### 1. Created Script Summaries
+* Created `IContainerInteractable.md` detailing the Interface architecture for interactive containers.
+* Created `ConsumableModule.md` detailing the Abstract Blueprint and Runtime State architecture for consumable items.
+* Created `DefensiveModule.md` detailing the Data Container architecture for defensive item stats.
+
+---
+
+## [Previous] - Documentation Updates
 This update addresses missing UI documentation and ensures all project documentation is centralized and correctly formatted according to project conventions.
 
 ### 1. Centralized Event Documentation

--- a/Toris/Assets/Documentation/Script_Descriptions/ConsumableModule.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/ConsumableModule.md
@@ -1,0 +1,31 @@
+Identifier: OutlandHaven.Inventory.ConsumableComponent : ItemComponent / OutlandHaven.Inventory.ConsumableState : ItemComponentState
+Architectural Role: Abstract Blueprint (ConsumableComponent) / Data Container (ConsumableState)
+
+Core Logic:
+- Abstract/Virtual Methods:
+  - `CreateInitialState()` [ConsumableComponent] -> Initializes and returns a new `ConsumableState` with `MaxCharges`.
+  - `IsStackableWith(ItemComponentState other)` [ConsumableState] -> Evaluates if another item can stack. Requirement: Exact match on `CurrentCharges`.
+  - `Clone()` [ConsumableState] -> Returns a deep copy of the current state.
+- Public API: N/A (Data/Blueprint focus)
+
+Dependency Graph:
+- Upstream:
+  - `OutlandHaven.Inventory.ItemComponent`
+  - `OutlandHaven.Inventory.ItemComponentState`
+  - `OutlandHaven.Inventory.ConsumptionSlot` (Enum)
+- Downstream:
+  - Consumed by Inventory System logic for item usage and stacking validation.
+  - Utilized by Player Effect/Stat systems upon usage (Implied via `EffectPayload`).
+
+Data Schema:
+- Blueprint (ConsumableComponent):
+  - `ConsumptionSlot EffectPayload` -> Defines target effect (HP, Mana).
+  - `int amount` -> Restoration/Effect magnitude.
+  - `float CooldownDuration` -> Time restriction between uses.
+  - `int MaxCharges` -> Base maximum uses.
+- Runtime State (ConsumableState):
+  - `int CurrentCharges` -> Tracks remaining uses.
+
+Side Effects & Lifecycle:
+- Instantiates `ConsumableState` heap objects via `CreateInitialState()` and `Clone()`.
+- Static rules defined in Blueprint; mutable state tracked in State class.

--- a/Toris/Assets/Documentation/Script_Descriptions/DefensiveModule.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/DefensiveModule.md
@@ -1,0 +1,19 @@
+Identifier: OutlandHaven.Inventory.DefensiveComponent : ItemComponent
+Architectural Role: Abstract Blueprint / Data Container
+
+Core Logic:
+- Abstract/Virtual Methods: N/A (Inherits default behavior)
+- Public API: N/A
+
+Dependency Graph:
+- Upstream:
+  - `OutlandHaven.Inventory.ItemComponent`
+- Downstream:
+  - Evaluated by Player Equipment/Stat systems (e.g. `PlayerEffectResolver`) to apply damage mitigation.
+
+Data Schema:
+- `float PhysicalDefense` -> Flat physical damage reduction.
+- `float MagicalDefense` -> Flat magical/elemental damage reduction.
+
+Side Effects & Lifecycle:
+- Pure data class. No custom initialization or state tracking. Relies entirely on parent `ItemComponent` lifecycle.

--- a/Toris/Assets/Documentation/Script_Descriptions/IContainerInteractable.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/IContainerInteractable.md
@@ -1,0 +1,21 @@
+Identifier: Global.IContainerInteractable : None
+Architectural Role: Interface / Component Logic Contract
+
+Core Logic:
+- Abstract/Virtual Methods:
+  - `bool Interact(InventoryManager targetContainer)` -> Execute interaction logic against a target container. Returns success state. Implementation should destroy item on success if consumable.
+  - `Vector3 InteractionPosition { get; }` -> Retrieve world space position for interaction range checks.
+  - `string GetInteractionPrompt()` -> Retrieve UI text prompt for interaction.
+- Public API: N/A (Interface definition)
+
+Dependency Graph:
+- Upstream:
+  - `UnityEngine.Vector3`
+  - `OutlandHaven.Inventory.InventoryManager`
+- Downstream:
+  - Implemented by interactive world objects (e.g. World Item Drops, Chests).
+
+Data Schema: N/A (Interface)
+
+Side Effects & Lifecycle:
+- Implementations expected to handle their own lifecycle (e.g., self-destruction upon successful `Interact`).


### PR DESCRIPTION
This pull request adds context-dense, key-value style metadata summaries for three specific C# scripts (`IContainerInteractable.cs`, `ConsumableModule.cs`, `DefensiveModule.cs`). These summaries are stored in the `Documentation/Script_Descriptions` folder and serve as primary references for AI agents to understand the script's role without reading the full source code.

- **`IContainerInteractable.md`**: Details the `IContainerInteractable` interface, outlining the `Interact` contract and its dependencies.
- **`ConsumableModule.md`**: Details the `ConsumableComponent` (blueprint) and `ConsumableState` (runtime tracker), including the `CreateInitialState` and stacking logic.
- **`DefensiveModule.md`**: Details the `DefensiveComponent` as a pure data container for mitigation stats.
- **CHANGELOG.md**: Added an entry detailing the newly created documentation.

---
*PR created automatically by Jules for task [11996905285585224992](https://jules.google.com/task/11996905285585224992) started by @sourcereris*