### PR TITLE
docs: Generate script metadata summaries

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -7,7 +7,22 @@
 
 ---
 
-## [Current/Recent] - Documentation Updates
+## [Current/Recent] - Script Documentation Generation
+This update adds Context-Dense Metadata Summaries for four core scripts within the Inventory Item Architecture, adhering strictly to the structured key-value format required by the project directives.
+
+### 1. Generated Documentation Summaries
+* Created `ProgressionModule.md` documenting `ProgressionComponent`.
+* Created `UpgradeableModule.md` documenting `UpgradeableComponent` and `UpgradeableState`.
+* Created `ItemComponent.md` documenting the abstract base `ItemComponent` class.
+* Created `ItemComponentState.md` documenting the abstract base `ItemComponentState` class.
+
+### 2. Standardization
+* Ensured all generated files adhere to the strict key-value formatting rules: Identifier, Architectural Role, Core Logic, Dependency Graph, Data Schema, and Side Effects & Lifecycle.
+* Omitted conversational language and used technical shorthand with bullet points.
+
+---
+
+## [Previous] - Documentation Updates
 This update addresses missing UI documentation and ensures all project documentation is centralized and correctly formatted according to project conventions.
 
 ### 1. Centralized Event Documentation

--- a/Toris/Assets/Documentation/Script_Descriptions/ItemComponent.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/ItemComponent.md
@@ -1,0 +1,18 @@
+Identifier: OutlandHaven.Inventory.ItemComponent : System.Object
+
+Architectural Role: Abstract Blueprint
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods:
+  - CreateInitialState() -> Can be overridden by derived blueprint components to generate dynamic runtime state trackers. Returns null by default.
+- Public API: None
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: None.
+- Downstream: Base class inherited by all item component definitions (e.g., `UpgradeableComponent`, `ProgressionComponent`). Read by inventory instantiation systems.
+
+Data Schema: None
+
+Side Effects & Lifecycle:
+- Does not hold runtime data.
+- Does not inherently allocate heap memory unless `CreateInitialState()` is overridden to do so by a child class.

--- a/Toris/Assets/Documentation/Script_Descriptions/ItemComponentState.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/ItemComponentState.md
@@ -1,0 +1,18 @@
+Identifier: OutlandHaven.Inventory.ItemComponentState : System.Object
+
+Architectural Role: Abstract Runtime State Data
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods:
+  - IsStackableWith(ItemComponentState other) -> MUST be overridden. Defines equivalence logic for inventory stacking.
+  - Clone() -> MUST be overridden. Returns a deep copy of the state data.
+- Public API: None
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: None.
+- Downstream: Base class inherited by all runtime component states (e.g., `UpgradeableState`). Validated by inventory slot merge arbitrators.
+
+Data Schema: None
+
+Side Effects & Lifecycle:
+- Abstract contract requires child classes to handle cloning allocations. Evaluated dynamically during inventory merge transactions.

--- a/Toris/Assets/Documentation/Script_Descriptions/ProgressionModule.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/ProgressionModule.md
@@ -1,0 +1,18 @@
+Identifier: OutlandHaven.UIToolkit.ProgressionComponent : OutlandHaven.Inventory.ItemComponent
+
+Architectural Role: Data Container / Blueprint Component
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API: None
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on OutlandHaven.Inventory.ItemComponent.
+- Downstream: Queried by inventory and UI systems for sorting and filtering logic.
+
+Data Schema:
+- ProgressionCategory Category -> Defines item type (Material, QuestItem, Key, Junk) for sorting and filtering logic.
+
+Side Effects & Lifecycle:
+- Does not create a runtime state override (no heap allocation for state).
+- Items are perfectly stackable by default.

--- a/Toris/Assets/Documentation/Script_Descriptions/UpgradeableModule.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/UpgradeableModule.md
@@ -1,0 +1,40 @@
+Identifier: OutlandHaven.Inventory.UpgradeableComponent : OutlandHaven.Inventory.ItemComponent
+
+Architectural Role: Abstract Blueprint & Blueprint Component
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods:
+  - CreateInitialState() -> Overridden to instantiate and return a new `UpgradeableState` initialized at level 1.
+- Public API: None
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on OutlandHaven.Inventory.ItemComponent.
+- Downstream: Instantiates `UpgradeableState`. Read by upgrade mechanics to cap item leveling.
+
+Data Schema:
+- int MaxLevel -> Defines the maximum upgrade level constraint.
+
+Side Effects & Lifecycle:
+- Allocates to the managed heap via `CreateInitialState()` to generate the runtime state container.
+
+---
+
+Identifier: OutlandHaven.Inventory.UpgradeableState : OutlandHaven.Inventory.ItemComponentState
+
+Architectural Role: Runtime State Data
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods:
+  - IsStackableWith(ItemComponentState other) -> Evaluates if another `UpgradeableState` has an identical `CurrentLevel`.
+  - Clone() -> Returns a new heap-allocated copy of the current state.
+- Public API: None
+
+Dependency Graph (Crucial for Scaling):
+- Upstream: Depends on OutlandHaven.Inventory.ItemComponentState.
+- Downstream: Modified by upgrade mechanic systems. Evaluated by inventory stacking arbitrators.
+
+Data Schema:
+- int CurrentLevel -> Tracks the current dynamic level of the specific item instance.
+
+Side Effects & Lifecycle:
+- Cloned state and initial state allocation generates heap allocations.


### PR DESCRIPTION
This PR adds context-dense metadata summaries for four scripts:
- ProgressionModule.cs
- UpgradeableModule.cs
- ItemComponent.cs
- ItemComponentState.cs

They follow the structured key-value format.

---
*PR created automatically by Jules for task [6721164786294362637](https://jules.google.com/task/6721164786294362637) started by @sourcereris*