### PR TITLE
docs: add script metadata summaries for AI agents

### DIFF
--- a/Toris/Assets/Documentation/Script_Descriptions/EquipmentEffectBridge.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/EquipmentEffectBridge.md
@@ -1,0 +1,31 @@
+Identifier: EquipmentEffectBridge : MonoBehaviour
+
+Architectural Role: Component Logic / Decoupled Event Adapter
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API:
+  - void RefreshSlot(EquipmentSlot slot): Manually forces update for a specific equipment slot.
+  - void RefreshAll(): Manually forces update across all equipment slots.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream:
+  - Requires `PlayerEquipmentController` (data source / event broadcaster).
+  - Depends on `PlayerEffectSourceController` (stat effect receiver).
+  - Depends on `ItemInstance` (item data and state events).
+  - Depends on `EquippedItemEffectSource` (wrapper class for effects).
+- Downstream:
+  - Subscribes to `ItemInstance.OnStateChanged`.
+
+Data Schema:
+- PlayerEquipmentController _equipment -> Provides equipped item references and fires equip/unequip events.
+- PlayerEffectSourceController _effectSourceController -> System handling active stat modifiers.
+- Dictionary<EquipmentSlot, ItemInstance> _subscribedItems -> Caches tracked items to manage event lifecycle.
+
+Side Effects & Lifecycle:
+- Reset/Awake: Auto-assigns `_equipment` via `GetComponent`.
+- OnEnable: Subscribes to `_equipment.OnEquippedItemChanged`.
+- OnDisable: Unsubscribes from `_equipment` and all tracked `ItemInstance.OnStateChanged` events, then clears `_subscribedItems` dictionary.
+- Start: Triggers `RefreshAll()` to apply initial loadout.
+- HandleEquippedItemChanged: Allocates `EquippedItemEffectSource` on heap when equip happens. Adds/removes sources via `_effectSourceController`. Subscribes/unsubscribes to `ItemInstance.OnStateChanged`.
+- HandleEquippedItemStateChanged: Listens to durability/upgrade changes on items and calls `RefreshSlot()`.

--- a/Toris/Assets/Documentation/Script_Descriptions/EquippedItemEffectSource.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/EquippedItemEffectSource.md
@@ -1,0 +1,26 @@
+Identifier: EquippedItemEffectSource : IPlayerEffectSource
+
+Architectural Role: Data Container / Component Logic Adapter
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None (Sealed class)
+- Public API:
+  - string SourceKey: Read-only property returning the unique identifier string.
+  - void CollectModifiers(List<PlayerEffectModifier> modifiers): Evaluates internal item and appends relevant offensive/defensive modifier structs into the provided list.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream:
+  - Implements `IPlayerEffectSource`.
+  - Depends on `ItemInstance` (raw data).
+  - Depends on `EquippedItemStatCalculator` (computes final values).
+  - Depends on `PlayerEffectModifier` (structs to output).
+- Downstream:
+  - Passed by `EquipmentEffectBridge` to `PlayerEffectSourceController`.
+
+Data Schema:
+- string _sourceKey -> Identifier (e.g., "Equipment_Weapon").
+- ItemInstance _item -> Reference to the item being evaluated.
+
+Side Effects & Lifecycle:
+- Constructor: Initializes fields without side effects.
+- CollectModifiers: Invokes `EquippedItemStatCalculator.Calculate(_item)`. Adds `PlayerEffectModifier` structs (value types) to the provided list (no heap allocation for the structs themselves if using list backing array).

--- a/Toris/Assets/Documentation/Script_Descriptions/EquippedItemStatCalculator.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/EquippedItemStatCalculator.md
@@ -1,0 +1,25 @@
+Identifier: EquippedItemStatCalculator : static class
+
+Architectural Role: Component Logic / Pure Function Calculator
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None (Static class)
+- Public API:
+  - EquippedItemComputedStats Calculate(ItemInstance item): Extracts component and dynamic state data from the item to assemble a unified stats struct.
+  - WeaponComputedStats CalculateWeapon(ItemInstance item): Calls `Calculate` internally and applies specific math (e.g., strength multipliers, upgrade bonus logic) for weapons.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream:
+  - Depends on `ItemInstance` (base object).
+  - Depends on `EquipableComponent`, `OffensiveComponent`, `DefensiveComponent`, `EvolvingComponent` (modular component data).
+  - Depends on `UpgradeableState`, `EvolvingState` (dynamic runtime states).
+  - Depends on `EquippedItemComputedStats`, `WeaponComputedStats` (return structs).
+- Downstream:
+  - Called by `EquippedItemEffectSource` (stat aggregation).
+  - Can be called by UI (e.g., tooltip rendering).
+
+Data Schema:
+- No instance or static fields. Operates purely on provided arguments.
+
+Side Effects & Lifecycle:
+- Pure functions: Does not modify inputs, maintains no internal state, uses Unity's `GetComponent` strictly on `item.BaseItem` (reads only). No allocations (returns structs).

--- a/Toris/Assets/Documentation/Script_Descriptions/InventoryManager.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/InventoryManager.md
@@ -1,0 +1,33 @@
+Identifier: OutlandHaven.Inventory.InventoryManager : MonoBehaviour
+
+Architectural Role: Component Logic / Data Container
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API:
+  - bool AddItem(ItemInstance itemInstance, int quantity): Adds quantity of items to available stacks or empty slots. Returns true if fully added, false if insufficient space.
+  - bool RemoveItem(ItemInstance itemInstance, int quantity): Removes quantity of items from matching stacks. Returns true if fully removed, false if insufficient quantity.
+
+Dependency Graph (Crucial for Scaling):
+- Upstream:
+  - Depends on `InventoryContainerSO` (rules/blueprint).
+  - Depends on `UIInventoryEventsSO` (event channel).
+  - Depends on `GameSessionSO` (global state).
+  - Depends on `ItemInstance` and `InventorySlot` (data classes).
+- Downstream:
+  - Observed by UIs listening to `UIInventoryEventsSO.OnInventoryUpdated`.
+  - Accessed by transaction systems (e.g., ShopManager) or interactables (e.g., WorldItem).
+
+Data Schema:
+- InventoryContainerSO ContainerBlueprint -> Rules and constraints (e.g., slot count, screen type).
+- List<InventorySlot> LiveSlots -> Active runtime data container.
+- UIInventoryEventsSO _uiInventoryEvents -> Broadcaster for state changes.
+- GameSessionSO GlobalSession -> Global registry.
+
+Side Effects & Lifecycle:
+- Awake: Synchronizes `LiveSlots` count to `ContainerBlueprint.SlotCount` via list mutation.
+- OnValidate (Editor only): Re-synchronizes `LiveSlots` count to prevent inspector drift.
+- OnEnable: If container is assigned as Player Inventory (via blueprint enum), injects `this` into `GlobalSession.PlayerInventory`.
+- OnDisable: Clears `this` from `GlobalSession.PlayerInventory` if currently set.
+- AddItem: Allocates `ItemInstance` clones on heap for new stacks. Triggers `OnInventoryUpdated` event.
+- RemoveItem: Modifies counts or calls `Clear()` on `LiveSlots`. Triggers `OnInventoryUpdated` event.

--- a/Toris/Assets/Documentation/Script_Descriptions/WorldItem.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/WorldItem.md
@@ -1,0 +1,30 @@
+Identifier: OutlandHaven.Inventory.WorldItem : MonoBehaviour, IContainerInteractable
+
+Architectural Role: Component Logic
+
+Core Logic (The 'Contract'):
+- Abstract/Virtual Methods: None
+- Public API:
+  - Vector3 InteractionPosition: Property returning offset interaction location.
+  - bool Interact(InventoryManager targetContainer): Core interaction logic. Attempts to instantiate `ItemInstance` from `_itemData` and injects it into `targetContainer`. Returns boolean success. On success, calls `Destroy(gameObject)`.
+  - string GetInteractionPrompt(): Returns raw string prompt for UI (e.g., "E").
+
+Dependency Graph (Crucial for Scaling):
+- Upstream:
+  - Requires `SpriteRenderer` (auto-configured).
+  - Requires `Collider2D` (configured as trigger).
+  - Depends on `InventoryItemSO` (blueprint data).
+  - Depends on `InventoryManager` (interaction target container).
+  - Depends on `ItemInstance` (runtime data wrapper).
+- Downstream:
+  - Observed by any player interaction raycaster or overlap query expecting `IContainerInteractable`.
+
+Data Schema:
+- InventoryItemSO _itemData -> Blueprint defining the item.
+- int _quantity -> Amount to add on pickup (default 1).
+
+Side Effects & Lifecycle:
+- Awake: Caches `SpriteRenderer` reference.
+- Start: Mutates `SpriteRenderer.sprite` and `gameObject.name` based on `_itemData`. Mutates `Collider2D.isTrigger` to true.
+- OnValidate: Emits console warning if `_itemData` is unassigned.
+- Interact: Allocates new `ItemInstance` on heap. Destroys `gameObject` upon successful transfer.


### PR DESCRIPTION
Added five new structured Markdown files inside `Toris/Assets/Documentation/Script_Descriptions/` to serve as reference material for other AI agents. The new summaries use a key-value format without conversational language, as requested, and cover:
- WorldItem
- InventoryManager
- EquipmentEffectBridge
- EquippedItemEffectSource
- EquippedItemStatCalculator

---
*PR created automatically by Jules for task [5544282158832084430](https://jules.google.com/task/5544282158832084430) started by @sourcereris*