### PR TITLE
📝 [documentation] update changelog and add skill screen architecture docs

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -1,11 +1,39 @@
-## [Current/Recent] - Refactored UI Currency Access
+## [Current/Recent] - Skill Screen Architecture Implementation
+This update introduces the foundational architecture for the Skill Screen, aligning with the project's MVC and Event Bus standards.
+
+### 1. UI Layout & Styling (UXML/USS)
+* **The Massive Canvas:** Utilized Flexbox inside a `ScrollView` (with hidden scrollbars) to create a large 1920x1080 panning area for the skill tree.
+* **The Info Panel:** Built a static side panel to display detailed information (name, description, cost, status) and hold the primary action button.
+* **Visual States:** Defined specific USS classes (`.skill-node--unlocked`, `--available`, `--locked`) to handle the coloring and opacity of nodes, plus pseudo-classes (`:disabled`, `:hover`) for the unlock button.
+
+### 2. Static Data (ScriptableObjects)
+* **The Blueprint:** Created `SkillData` ScriptableObjects to hold the static identity of each skill (ID, name, cost, text, and an array of prerequisite `SkillData`).
+* **The Separation:** Ensures dynamic player save files are not bloated with static text and icon references.
+
+### 3. Dynamic Data Model (Pure C#)
+* **The Tracker:** Built `PlayerSkillTracker`, a pure, serializable C# class living inside `GameSessionSO` (the ultimate source of truth).
+* **The Logic:** Securely handles deducting SP, adding unlocked IDs to a HashSet, and evaluating if prerequisites are met.
+
+### 4. Event Bus Architecture (ScriptableObjects)
+* **The Decoupling:** Created `UISkillEventsSO` to prevent the UI from directly modifying the save data.
+* **The Manager:** Established a `SkillManager` MonoBehaviour to listen for the UI's `OnRequestUnlock` event, validate the math against the `GameSessionSO`, and broadcast back the success state.
+
+### 5. The View (C# UI Logic)
+* **The Mapping:** In `PlayerSkillView.cs`, used a Dictionary to map UXML `<ui:Button>` elements directly to their respective `SkillData` IDs.
+* **Data Injection:** Injects SO data into the Info Panel labels when a node is clicked.
+* **State Updates:** Wrote `RefreshAllNodes()`, sweeping the tree every time it opens (or a skill is bought) to dynamically add or remove the USS locked/available/unlocked classes based on the Tracker's logic.
+
+### 6. The Controller (MonoBehaviour)
+* **The Initialization:** Refactored `SkillScreenController.cs` to instantiate the UXML, inject the `SkillData[]` database and the `GameSessionSO` into the View, and register it directly into the `UIManager`'s FullScreen zone.
+
+## [Previous] - Refactored UI Currency Access
 * Replaced `PlayerProgressionAnchorSO` with `PlayerHUDBridge` in `ShopSubView` and related controllers (`SmithScreenController`, `MageScreenController`).
 * UI views now strictly observe `PlayerHUDBridge.OnGoldChanged` instead of global event channels for currency updates.
 * Removed redundant `OnCurrencyChanged` event from `UIInventoryEventsSO` to prevent race conditions.
 * Updated `ShopManagerSO`, `SalvageManagerSO`, and `CraftingManagerSO` to not invoke `OnCurrencyChanged`.
 * Removed unused `PlayerStatsAnchorSO` from `HudScreenController`.
 
-## [Current/Recent] - Cleanup redundant skill view script
+## [Previous] - Cleanup redundant skill view script
 This update removes redundant scripts for the skill tree UI and consolidates its logic into the actively used views and data structures.
 
 ### 1. Removed `SkillsView.cs`

--- a/Toris/Assets/Documentation/Script_Descriptions/PlayerSkillTracker.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/PlayerSkillTracker.md
@@ -1,0 +1,15 @@
+Identifier: `PlayerSkillTracker`
+Architectural Role: Core Logic / Data Model
+Core Logic (Abstract/Virtual Methods, Public API):
+- `AddSP(int amount)`: Increases available SP.
+- `TryUnlockSkill(SkillData skill)`: Attempts to unlock a skill, checking SP cost and prerequisites. Returns true on success.
+- `ArePrerequisitesMet(SkillData skill)`: Checks if all prerequisites for a skill are met.
+- `HasSkill(string skillID)`: Checks if a skill ID exists in the unlocked list.
+Dependency Graph (Upstream/Downstream):
+- Upstream: `SkillManager` (invokes `TryUnlockSkill`).
+- Downstream: `SkillData` (reads prerequisites and cost).
+Data Schema:
+- `_availableSP` (int)
+- `_unlockedSkillIDs` (List<string>)
+Side Effects & Lifecycle:
+- Serialized class stored in `GameSessionSO` or similar save data wrapper.

--- a/Toris/Assets/Documentation/Script_Descriptions/PlayerSkillTracker.md.meta
+++ b/Toris/Assets/Documentation/Script_Descriptions/PlayerSkillTracker.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a123456789abcdef0123456789abcdef
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Toris/Assets/Documentation/Script_Descriptions/SkillManager.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/SkillManager.md
@@ -1,0 +1,11 @@
+Identifier: `OutlandHaven.Skills.SkillManager`
+Architectural Role: Manager / Presenter Logic
+Core Logic (Abstract/Virtual Methods, Public API):
+- `HandleUnlockRequest(SkillData skill)`: Attempts to unlock a skill using `GameSessionSO.PlayerSkills.TryUnlockSkill(skill)`. If successful, broadcasts `OnSkillUnlocked` and `OnSPUpdated`.
+Dependency Graph (Upstream/Downstream):
+- Upstream: `UISkillEventsSO` (listens to `OnRequestUnlock`).
+- Downstream: `GameSessionSO` (modifies `PlayerSkillTracker`), `UISkillEventsSO` (invokes update events).
+Data Schema:
+- None
+Side Effects & Lifecycle:
+- Binds to `UISkillEventsSO.OnRequestUnlock` during `OnEnable`, unbinds in `OnDisable`.

--- a/Toris/Assets/Documentation/Script_Descriptions/SkillManager.md.meta
+++ b/Toris/Assets/Documentation/Script_Descriptions/SkillManager.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b123456789abcdef0123456789abcdef
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Toris/Assets/Documentation/Script_Descriptions/UISkillEventsSO.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/UISkillEventsSO.md
@@ -1,0 +1,10 @@
+Identifier: `OutlandHaven.Skills.UISkillEventsSO`
+Architectural Role: Event Bus / Decoupling Layer
+Core Logic (Abstract/Virtual Methods, Public API):
+- Provides `UnityAction` events for system-to-UI (`OnSPUpdated`, `OnSkillUnlocked`) and UI-to-system (`OnRequestUnlock`) communication.
+Dependency Graph (Upstream/Downstream):
+- Upstream: `SkillManager` (listens to `OnRequestUnlock`, invokes `OnSPUpdated`, `OnSkillUnlocked`), `PlayerSkillView` (listens to `OnSkillUnlocked`, invokes `OnRequestUnlock`).
+Data Schema:
+- None
+Side Effects & Lifecycle:
+- Static event bus instantiated as a ScriptableObject.

--- a/Toris/Assets/Documentation/Script_Descriptions/UISkillEventsSO.md.meta
+++ b/Toris/Assets/Documentation/Script_Descriptions/UISkillEventsSO.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c123456789abcdef0123456789abcdef
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
This PR updates the project documentation and changelog to reflect the newly implemented Skill Screen architecture based on the MVC and Event Bus standards.

**🎯 What:**
* Added a new entry at the top of `CHANGELOG.md` detailing the 6 core components of the new Skill Screen architecture.
* Created Context-Dense Metadata Summary markdown files (`PlayerSkillTracker.md`, `SkillManager.md`, `UISkillEventsSO.md`) in `Toris/Assets/Documentation/Script_Descriptions/`.
* Created corresponding `.meta` files for the new markdown files.

**💡 Why:**
To maintain accurate project documentation and comply with the changelog requirements outlined in the `AGENTS.md` and repository guidelines.

**✅ Verification:**
* Verified the generation of the documentation files and their respective `.meta` files.
* Confirmed the formatting of `CHANGELOG.md` adheres to the established project style.

---
*PR created automatically by Jules for task [2017198243911179659](https://jules.google.com/task/2017198243911179659) started by @sourcereris*