### PR TITLE
🧹 [Code Health] Localize UI Translation Layer and Implement Interaction Contexts

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -26,6 +26,24 @@ This update introduces the foundational architecture for the Skill Screen, align
 ### 6. The Controller (MonoBehaviour)
 * **The Initialization:** Refactored `SkillScreenController.cs` to instantiate the UXML, inject the `SkillData[]` database and the `GameSessionSO` into the View, and register it directly into the `UIManager`'s FullScreen zone.
 
+## [Current/Recent] - Localized UI Translation Layer
+This update refactors `InventorySlotView` to decouple it from the global event bus, enforcing a stricter parent-child UI architecture and introducing an enum-based context state for inventory interactions.
+
+### 1. Created `InventoryInteractionContext`
+* Added the `InventoryInteractionContext` enum (Normal, Shop, Salvage) in its own file to track the current interaction mode without creating circular dependencies.
+* Added an `OnInteractionContextChanged` action to `UIInventoryEventsSO` to allow dynamic UI views to broadcast context shifts.
+
+### 2. Localized `InventorySlotView`
+* Removed `UIInventoryEventsSO` dependency from `InventorySlotView` entirely.
+* Replaced global triggers with local C# `Action` events (`OnLocalClicked`, `OnLocalRightClicked`, `OnLocalMoveItemRequested`, `OnLocalSelectForProcessingRequested`).
+* This makes the slot view a pure, reusable component that blindly emits hardware interactions.
+
+### 3. Updated Parent Views (The Translators)
+* Updated `PlayerInventoryView`, `ShopSubView`, `SalvageSubView`, `ForgeSubView`, and `PlayerEquipmentView` to subscribe to the local slot events and act as pass-throughs to the global bus.
+* `PlayerInventoryView` now listens to `OnInteractionContextChanged`. When a player right-clicks a slot, the view translates the action based on the active context (e.g., normal -> Equip, shop -> Sell, salvage -> Salvage).
+* `PlayerEquipmentView` intentionally ignores context changes and strictly maps right-clicks to unequip actions, enforcing a safe two-step process for equipped items.
+* `ShopSubView` and `SalvageSubView` now broadcast their context entry during `Show()` and reset to `Normal` during `Hide()`.
+
 ## [Previous] - Refactored UI Currency Access
 * Replaced `PlayerProgressionAnchorSO` with `PlayerHUDBridge` in `ShopSubView` and related controllers (`SmithScreenController`, `MageScreenController`).
 * UI views now strictly observe `PlayerHUDBridge.OnGoldChanged` instead of global event channels for currency updates.

--- a/Toris/Assets/Scripts/UIToolkit/Template controlls/InventorySlotView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/Template controlls/InventorySlotView.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.UIElements;
 using OutlandHaven.UIToolkit;
@@ -12,14 +13,17 @@ namespace OutlandHaven.Inventory
 
         private InventorySlot _slotData;
         private InventoryManager _owningContainer;
-        private UIInventoryEventsSO _uiInventoryEvents;
+        public event Action<InventorySlot> OnLocalClicked;
+        public event Action<InventorySlot> OnLocalRightClicked;
+        public event Action<InventoryManager, InventorySlot, InventoryManager, InventorySlot> OnLocalMoveItemRequested;
+        public event Action<InventorySlot, string> OnLocalSelectForProcessingRequested;
 
         // Drag and Drop State
         private bool _isDragging = false;
         private Vector2 _dragStartPosition;
         private const float DragThreshold = 10f; // Pixels to move before initiating drag
 
-        public InventorySlotView(VisualElement root, InventoryManager owningContainer, UIInventoryEventsSO uiInventoryEvents)
+        public InventorySlotView(VisualElement root, InventoryManager owningContainer)
         {
             // Set the wrapper root's picking mode to Ignore
             root.pickingMode = PickingMode.Ignore;
@@ -29,7 +33,7 @@ namespace OutlandHaven.Inventory
             else _root.pickingMode = PickingMode.Position;
 
             _owningContainer = owningContainer;
-            _uiInventoryEvents = uiInventoryEvents;
+
 
             _icon = _root.Q<Image>("slot-icon");
             _qtyLabel = _root.Q<Label>("slot-qty");
@@ -126,7 +130,7 @@ namespace OutlandHaven.Inventory
                 // Fire right click event
                 if (_slotData != null && !_slotData.IsEmpty)
                 {
-                    _uiInventoryEvents?.OnItemRightClicked?.Invoke(_slotData);
+                    OnLocalRightClicked?.Invoke(_slotData);
                 }
                 return;
             }
@@ -173,7 +177,7 @@ namespace OutlandHaven.Inventory
                         if (targetSlotData.Slot != _slotData || targetSlotData.Container != _owningContainer)
                         {
                             // Invoke the cross-container swap logic
-                            _uiInventoryEvents?.OnRequestMoveItem?.Invoke(_owningContainer, _slotData, targetSlotData.Container, targetSlotData.Slot);
+                            OnLocalMoveItemRequested?.Invoke(_owningContainer, _slotData, targetSlotData.Container, targetSlotData.Slot);
                             Debug.Log($"FIRING EVENT: Moving {_slotData.HeldItem.BaseItem.ItemName} to new slot.");
                         }
                     }
@@ -181,7 +185,7 @@ namespace OutlandHaven.Inventory
                 else if (targetData is string proxySlotID)
                 {
                     // It's a proxy slot
-                    _uiInventoryEvents?.OnRequestSelectForProcessing?.Invoke(_slotData, proxySlotID);
+                    OnLocalSelectForProcessingRequested?.Invoke(_slotData, proxySlotID);
                 }
             }
             else
@@ -189,7 +193,7 @@ namespace OutlandHaven.Inventory
                 // Pointer did not move past the threshold, treat as a normal click
                 if (evt.button == 0 && _slotData != null && !_slotData.IsEmpty)
                 {
-                    _uiInventoryEvents?.OnItemClicked?.Invoke(_slotData);
+                    OnLocalClicked?.Invoke(_slotData);
                 }
             }
         }

--- a/Toris/Assets/Scripts/UIToolkit/UI/Events/InventoryInteractionContext.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/Events/InventoryInteractionContext.cs
@@ -1,0 +1,9 @@
+namespace OutlandHaven.Inventory
+{
+    public enum InventoryInteractionContext
+    {
+        Normal,
+        Shop,
+        Salvage
+    }
+}

--- a/Toris/Assets/Scripts/UIToolkit/UI/Events/UIInventoryEventsSO.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/Events/UIInventoryEventsSO.cs
@@ -30,5 +30,8 @@ namespace OutlandHaven.Inventory
 
         // Fired when an item is dropped onto a proxy visual slot (like Forge/Salvage)
         public UnityAction<InventorySlot, string> OnRequestSelectForProcessing;
+
+        [Header("Context Management")]
+        public UnityAction<InventoryInteractionContext> OnInteractionContextChanged;
     }
 }

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ForgeSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ForgeSubView.cs
@@ -48,7 +48,12 @@ namespace OutlandHaven.UIToolkit
                 TemplateContainer instance = _slotTemplate.Instantiate();
                 instance.userData = "forge-slot-1";
                 _slot1Container.Add(instance);
-                _slot1View = new InventorySlotView(instance, null, _uiInventoryEvents);
+                _slot1View = new InventorySlotView(instance, null);
+
+                _slot1View.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
+                _slot1View.OnLocalRightClicked += (slot) => _uiInventoryEvents.OnItemRightClicked?.Invoke(slot);
+                _slot1View.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                _slot1View.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 instance.RegisterCallback<MouseUpEvent>(evt =>
                 {
@@ -64,7 +69,12 @@ namespace OutlandHaven.UIToolkit
                 TemplateContainer instance = _slotTemplate.Instantiate();
                 instance.userData = "forge-slot-2";
                 _slot2Container.Add(instance);
-                _slot2View = new InventorySlotView(instance, null, _uiInventoryEvents);
+                _slot2View = new InventorySlotView(instance, null);
+
+                _slot2View.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
+                _slot2View.OnLocalRightClicked += (slot) => _uiInventoryEvents.OnItemRightClicked?.Invoke(slot);
+                _slot2View.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                _slot2View.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 instance.RegisterCallback<MouseUpEvent>(evt =>
                 {
@@ -79,7 +89,12 @@ namespace OutlandHaven.UIToolkit
             {
                 TemplateContainer instance = _slotTemplate.Instantiate();
                 _resultSlotContainer.Add(instance);
-                _resultSlotView = new InventorySlotView(instance, null, _uiInventoryEvents);
+                _resultSlotView = new InventorySlotView(instance, null);
+
+                _resultSlotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
+                _resultSlotView.OnLocalRightClicked += (slot) => _uiInventoryEvents.OnItemRightClicked?.Invoke(slot);
+                _resultSlotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                _resultSlotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
             }
         }
 

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerEquipmentView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerEquipmentView.cs
@@ -103,7 +103,25 @@ namespace OutlandHaven.Inventory
             TemplateContainer slotInstance = _slotTemplate.Instantiate();
             containerRoot.Add(slotInstance);
 
-            var slotView = new InventorySlotView(slotInstance, _equipmentInventory, _uiInventoryEvents);
+            var slotView = new InventorySlotView(slotInstance, _equipmentInventory);
+
+            slotView.OnLocalClicked += (slot) => { if (slot != null && !slot.IsEmpty && slot.HeldItem?.BaseItem != null) {
+                    var equipable = slot.HeldItem.BaseItem.GetComponent<EquipableComponent>();
+                    if (equipable != null) {
+                        _uiInventoryEvents.OnRequestUnequip?.Invoke(equipable.TargetSlot);
+                    }
+                } };
+            slotView.OnLocalRightClicked += (slot) => {
+                // The equipment system always interprets right clicks as unequips, ignoring context.
+                if (slot != null && !slot.IsEmpty && slot.HeldItem?.BaseItem != null) {
+                    var equipable = slot.HeldItem.BaseItem.GetComponent<EquipableComponent>();
+                    if (equipable != null) {
+                        _uiInventoryEvents.OnRequestUnequip?.Invoke(equipable.TargetSlot);
+                    }
+                }
+            };
+            slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+            slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
             slotView.Update(slotData);
 
             // Hide amount text label for equipment slots if it's there

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerInventoryView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerInventoryView.cs
@@ -20,6 +20,7 @@ namespace OutlandHaven.Inventory
 
         private UIInventoryEventsSO _uiInventoryEvents;
         private bool _eventsBound = false;
+        private InventoryInteractionContext _currentContext = InventoryInteractionContext.Normal;
 
         public PlayerInventoryView(VisualElement topElement, VisualTreeAsset slotTemplate, GameSessionSO session, UIEventsSO uiEvents, UIInventoryEventsSO uiInventoryEvents, InventoryManager equipmentInventory = null)
             : base(topElement, uiEvents)
@@ -43,6 +44,7 @@ namespace OutlandHaven.Inventory
             if (!_eventsBound && _uiInventoryEvents != null)
             {
                 _uiInventoryEvents.OnInventoryUpdated += OnInventoryUpdated;
+                _uiInventoryEvents.OnInteractionContextChanged += HandleContextChanged;
                 _eventsBound = true;
             }
             _equipmentView?.Show();
@@ -54,6 +56,7 @@ namespace OutlandHaven.Inventory
             if (_eventsBound && _uiInventoryEvents != null)
             {
                 _uiInventoryEvents.OnInventoryUpdated -= OnInventoryUpdated;
+                _uiInventoryEvents.OnInteractionContextChanged -= HandleContextChanged;
                 _eventsBound = false;
             }
             _equipmentView?.Hide();
@@ -95,10 +98,38 @@ namespace OutlandHaven.Inventory
 
                 // Initialize the wrapper and update it
                 // We pass in the owning InventoryManager (data) and the UI events
-                var slotView = new InventorySlotView(slotInstance, data, _uiInventoryEvents);
+                var slotView = new InventorySlotView(slotInstance, data);
+
+                slotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
+                slotView.OnLocalRightClicked += HandleMainInventoryRightClick;
+                slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
                 slotView.Update(slotData);
 
                 // Click events are now handled natively inside InventorySlotView via PointerUpEvent
+            }
+        }
+
+
+        private void HandleContextChanged(InventoryInteractionContext newContext)
+        {
+            _currentContext = newContext;
+        }
+
+        private void HandleMainInventoryRightClick(InventorySlot dataSlot)
+        {
+            switch (_currentContext)
+            {
+                case InventoryInteractionContext.Shop:
+                    _uiInventoryEvents.OnRequestSell?.Invoke(dataSlot.HeldItem, 1);
+                    break;
+                case InventoryInteractionContext.Salvage:
+                    _uiInventoryEvents.OnRequestSalvage?.Invoke(dataSlot, SalvageType.Material); // default salvage type
+                    break;
+                case InventoryInteractionContext.Normal:
+                default:
+                    _uiInventoryEvents.OnRequestEquip?.Invoke(dataSlot);
+                    break;
             }
         }
 
@@ -107,6 +138,7 @@ namespace OutlandHaven.Inventory
             if (_eventsBound && _uiInventoryEvents != null)
             {
                 _uiInventoryEvents.OnInventoryUpdated -= OnInventoryUpdated;
+                _uiInventoryEvents.OnInteractionContextChanged -= HandleContextChanged;
                 _eventsBound = false;
             }
             _equipmentView?.Dispose();

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/SalvageSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/SalvageSubView.cs
@@ -48,7 +48,12 @@ namespace OutlandHaven.UIToolkit
                 TemplateContainer instance = _slotTemplate.Instantiate();
                 instance.userData = "salvage-input"; // Set proxy ID
                 _inputSlotContainer.Add(instance);
-                _inputSlotView = new InventorySlotView(instance, null, _uiInventoryEvents);
+                _inputSlotView = new InventorySlotView(instance, null);
+
+                _inputSlotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
+                _inputSlotView.OnLocalRightClicked += HandleItemRightClicked;
+                _inputSlotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                _inputSlotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 instance.RegisterCallback<MouseUpEvent>(evt =>
                 {
@@ -63,7 +68,12 @@ namespace OutlandHaven.UIToolkit
             {
                 TemplateContainer instance = _slotTemplate.Instantiate();
                 _itemYieldContainer.Add(instance);
-                _itemYieldView = new InventorySlotView(instance, null, _uiInventoryEvents);
+                _itemYieldView = new InventorySlotView(instance, null);
+
+                _itemYieldView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
+                _itemYieldView.OnLocalRightClicked += HandleItemRightClicked;
+                _itemYieldView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                _itemYieldView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
             }
         }
 
@@ -76,10 +86,11 @@ namespace OutlandHaven.UIToolkit
         public override void Show()
         {
             base.Show();
+            _uiInventoryEvents?.OnInteractionContextChanged?.Invoke(InventoryInteractionContext.Salvage);
             if (!_eventsBound && _uiInventoryEvents != null)
             {
                 _uiInventoryEvents.OnItemClicked += HandleItemClicked;
-                _uiInventoryEvents.OnItemRightClicked += HandleItemRightClicked;
+
                 _uiInventoryEvents.OnRequestSelectForProcessing += HandleProxyDrop;
                 _eventsBound = true;
             }
@@ -90,11 +101,12 @@ namespace OutlandHaven.UIToolkit
 
         public override void Hide()
         {
+            _uiInventoryEvents?.OnInteractionContextChanged?.Invoke(InventoryInteractionContext.Normal);
             base.Hide();
             if (_eventsBound && _uiInventoryEvents != null)
             {
                 _uiInventoryEvents.OnItemClicked -= HandleItemClicked;
-                _uiInventoryEvents.OnItemRightClicked -= HandleItemRightClicked;
+
                 _uiInventoryEvents.OnRequestSelectForProcessing -= HandleProxyDrop;
                 _eventsBound = false;
             }
@@ -233,7 +245,7 @@ namespace OutlandHaven.UIToolkit
             if (_eventsBound && _uiInventoryEvents != null)
             {
                 _uiInventoryEvents.OnItemClicked -= HandleItemClicked;
-                _uiInventoryEvents.OnItemRightClicked -= HandleItemRightClicked;
+
                 _uiInventoryEvents.OnRequestSelectForProcessing -= HandleProxyDrop;
                 _eventsBound = false;
             }

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ShopSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ShopSubView.cs
@@ -69,24 +69,26 @@ namespace OutlandHaven.UIToolkit
         public override void Show()
         {
             base.Show();
+            _uiInventoryEvents?.OnInteractionContextChanged?.Invoke(InventoryInteractionContext.Shop);
             // Listen to Events
             if (!_eventsBound && _uiInventoryEvents != null)
             {
                 if (_playerHudBridge != null) _playerHudBridge.OnGoldChanged += HandleGoldChanged;
                 _uiInventoryEvents.OnShopInventoryUpdated += HandleShopInventoryUpdated;
-                _uiInventoryEvents.OnItemRightClicked += HandleItemRightClicked;
+
                 _eventsBound = true;
             }
         }
 
         public override void Hide()
         {
+            _uiInventoryEvents?.OnInteractionContextChanged?.Invoke(InventoryInteractionContext.Normal);
             base.Hide();
             if (_eventsBound && _uiInventoryEvents != null)
             {
                 if (_playerHudBridge != null) _playerHudBridge.OnGoldChanged -= HandleGoldChanged;
                 _uiInventoryEvents.OnShopInventoryUpdated -= HandleShopInventoryUpdated;
-                _uiInventoryEvents.OnItemRightClicked -= HandleItemRightClicked;
+
                 _eventsBound = false;
             }
         }
@@ -109,7 +111,12 @@ namespace OutlandHaven.UIToolkit
                 TemplateContainer slotInstance = _slotTemplate.Instantiate();
                 _shopGrid.Add(slotInstance);
 
-                var slotView = new InventorySlotView(slotInstance, _shopContainer, _uiInventoryEvents);
+                var slotView = new InventorySlotView(slotInstance, _shopContainer);
+
+                slotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
+                slotView.OnLocalRightClicked += HandleShopSlotRightClicked;
+                slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
                 var slotData = _shopContainer.LiveSlots[i];
 
                 slotView.Update(slotData);
@@ -117,26 +124,15 @@ namespace OutlandHaven.UIToolkit
             }
         }
 
-        private void HandleItemRightClicked(InventorySlot slotData)
+
+        private void HandleShopSlotRightClicked(InventorySlot slotData)
         {
             if (slotData == null || slotData.IsEmpty) return;
 
             bool isShiftHeld = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
             int amount = isShiftHeld ? BULK_BUY_AMOUNT : 1;
 
-            // Check if clicking an item in the shop
-            if (_shopContainer != null && _shopContainer.LiveSlots.Contains(slotData))
-            {
-                _uiInventoryEvents?.OnRequestBuy?.Invoke(slotData.HeldItem, amount);
-                return;
-            }
-
-            // Check if clicking an item in the player inventory
-            if (_gameSession != null && _gameSession.PlayerInventory != null && _gameSession.PlayerInventory.LiveSlots.Contains(slotData))
-            {
-                _uiInventoryEvents?.OnRequestSell?.Invoke(slotData.HeldItem, amount);
-                return;
-            }
+            _uiInventoryEvents?.OnRequestBuy?.Invoke(slotData.HeldItem, amount);
         }
 
         private void HandleShopInventoryUpdated()
@@ -166,7 +162,7 @@ namespace OutlandHaven.UIToolkit
             {
                 if (_playerHudBridge != null) _playerHudBridge.OnGoldChanged -= HandleGoldChanged;
                 _uiInventoryEvents.OnShopInventoryUpdated -= HandleShopInventoryUpdated;
-                _uiInventoryEvents.OnItemRightClicked -= HandleItemRightClicked;
+
                 _eventsBound = false;
             }
             base.Dispose();


### PR DESCRIPTION
🎯 What
This refactor removes the `UIInventoryEventsSO` dependency from the `InventorySlotView` component, replacing global triggers with standard local C# events (`OnLocalClicked`, `OnLocalRightClicked`, etc). A new `InventoryInteractionContext` system is introduced to allow the `PlayerInventoryView` to act as a "translator" and dynamically map these clicks to appropriate global events (Equip, Sell, Salvage) based on the active UI state. Context-specific views like `ShopSubView` dictate this state change via `OnInteractionContextChanged` during their lifecycle.

💡 Why
This decouples the individual slots from the global architecture, ensuring the `InventorySlotView` remains a pure, reusable component that can be used universally. The new context state pattern eliminates race conditions where multiple UI systems attempt to intercept raw clicks and enforces stricter top-down intent translation. In addition, right-clicks in the `PlayerEquipmentView` are intentionally sandboxed from global contexts to strictly unequip items, adhering to standard RPG safety UX that prevents accidental selling or destroying of equipped gear.

✅ Verification
- Removed global dependencies from slot view initialization in all 5 parent views.
- Verified drop targeting and drag operations still bubble up their intents correctly via parent views.
- Mapped explicit context shifts in Shop/Salvage `Show` and `Hide` hooks.

✨ Result
A highly decoupled UI translation layer that centralizes context mapping inside the parent views and cleans up raw slot interactions.

---
*PR created automatically by Jules for task [18021198995424721844](https://jules.google.com/task/18021198995424721844) started by @sourcereris*