### PR TITLE
🧹 [Code Health] Refactor Drag and Drop Architecture

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -1,4 +1,20 @@
-## [Current/Recent] - Decoupled Inventory Transfer Manager
+## [Current/Recent] - Refactored Drag-and-Drop to Event-Driven Architecture
+
+### 1. Removed Singleton Dependency
+* Removed the Singleton pattern from `UIDragManager`, completely decoupling it from `InventorySlotView`.
+
+### 2. Implemented Local Events
+* Added `OnLocalDragStarted`, `OnLocalDragUpdated`, and `OnLocalDragStopped` events to `InventorySlotView`.
+
+### 3. Updated Global Event Bus
+* Added `OnGlobalDragStarted`, `OnGlobalDragUpdated`, and `OnGlobalDragStopped` to `UIInventoryEventsSO` to act as a global channel for visual drag states.
+
+### 4. Added View Translation
+* Updated `PlayerInventoryView`, `PlayerEquipmentView`, `ForgeSubView`, `SalvageSubView`, and `ShopSubView` to act as translators, listening to local slot drag events and forwarding them to the global `UIInventoryEventsSO`.
+
+---
+
+## [Previous] - Decoupled Inventory Transfer Manager
 
 ### 1. Added SlotFilterType to InventorySlot
 * Added a new `SlotFilterType` enum safely mapped to `EquipmentSlot` integer values.

--- a/Toris/Assets/Scripts/UIToolkit/Template controlls/InventorySlotView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/Template controlls/InventorySlotView.cs
@@ -18,6 +18,10 @@ namespace OutlandHaven.Inventory
         public event Action<InventoryManager, InventorySlot, InventoryManager, InventorySlot> OnLocalMoveItemRequested;
         public event Action<InventorySlot, string> OnLocalSelectForProcessingRequested;
 
+        public event Action<Sprite, Vector2, Vector2> OnLocalDragStarted;
+        public event Action<Vector2> OnLocalDragUpdated;
+        public event Action OnLocalDragStopped;
+
         // Drag and Drop State
         private bool _isDragging = false;
         private Vector2 _dragStartPosition;
@@ -106,12 +110,12 @@ namespace OutlandHaven.Inventory
                 {
                     _isDragging = true;
                     Vector2 iconSize = new Vector2(_icon.layout.width, _icon.layout.height);
-                    UIDragManager.Instance?.StartDrag(_slotData.HeldItem.BaseItem.Icon, evt.position, iconSize);
+                    OnLocalDragStarted?.Invoke(_slotData.HeldItem.BaseItem.Icon, evt.position, iconSize);
                 }
             }
             else
             {
-                UIDragManager.Instance?.UpdateDrag(evt.position);
+                OnLocalDragUpdated?.Invoke(evt.position);
             }
         }
 
@@ -125,7 +129,7 @@ namespace OutlandHaven.Inventory
             {
                 // Stop dragging state and clear visual ghost if any
                 _isDragging = false;
-                UIDragManager.Instance?.StopDrag();
+                OnLocalDragStopped?.Invoke();
 
                 // Fire right click event
                 if (_slotData != null && !_slotData.IsEmpty)
@@ -139,7 +143,7 @@ namespace OutlandHaven.Inventory
             {
                 // Stop dragging state and clear visual ghost
                 _isDragging = false;
-                UIDragManager.Instance?.StopDrag();
+                OnLocalDragStopped?.Invoke();
 
                 // 1. Perform the raycast to pick the element underneath the pointer
                 VisualElement targetElement = _root.panel.Pick(evt.position);

--- a/Toris/Assets/Scripts/UIToolkit/UI/Events/UIInventoryEventsSO.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/Events/UIInventoryEventsSO.cs
@@ -31,6 +31,11 @@ namespace OutlandHaven.Inventory
         // Fired when an item is dropped onto a proxy visual slot (like Forge/Salvage)
         public UnityAction<InventorySlot, string> OnRequestSelectForProcessing;
 
+        [Header("Drag and Drop Visuals")]
+        public System.Action<Sprite, Vector2, Vector2> OnGlobalDragStarted;
+        public System.Action<Vector2> OnGlobalDragUpdated;
+        public System.Action OnGlobalDragStopped;
+
         [Header("Context Management")]
         public UnityAction<InventoryInteractionContext> OnInteractionContextChanged;
     }

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/DragAndDrop/UIDragManager.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/DragAndDrop/UIDragManager.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UIElements;
+using OutlandHaven.Inventory;
 
 namespace OutlandHaven.UIToolkit
 {
@@ -8,22 +9,13 @@ namespace OutlandHaven.UIToolkit
         [Tooltip("Assign the same UIDocument used by UIManager here.")]
         [SerializeField] private UIDocument _uiDocument;
 
+        [SerializeField] private UIInventoryEventsSO _uiInventoryEvents;
+
         private VisualElement _dragLayer;
         private VisualElement _ghostIcon;
 
-        // Using a Singleton approach for easy global access from InventorySlotView,
-        // without needing to pass references through every view layer.
-        public static UIDragManager Instance { get; private set; }
-
         private void Awake()
         {
-            if (Instance != null && Instance != this)
-            {
-                Destroy(gameObject);
-                return;
-            }
-            Instance = this;
-
             if (_uiDocument == null)
             {
                 _uiDocument = GetComponent<UIDocument>();
@@ -41,6 +33,23 @@ namespace OutlandHaven.UIToolkit
             if (_dragLayer == null && _uiDocument != null && _uiDocument.rootVisualElement != null)
             {
                 InitializeDragLayer(_uiDocument.rootVisualElement);
+            }
+
+            if (_uiInventoryEvents != null)
+            {
+                _uiInventoryEvents.OnGlobalDragStarted += StartDrag;
+                _uiInventoryEvents.OnGlobalDragUpdated += UpdateDrag;
+                _uiInventoryEvents.OnGlobalDragStopped += StopDrag;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_uiInventoryEvents != null)
+            {
+                _uiInventoryEvents.OnGlobalDragStarted -= StartDrag;
+                _uiInventoryEvents.OnGlobalDragUpdated -= UpdateDrag;
+                _uiInventoryEvents.OnGlobalDragStopped -= StopDrag;
             }
         }
 

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ForgeSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ForgeSubView.cs
@@ -55,6 +55,10 @@ namespace OutlandHaven.UIToolkit
                 _slot1View.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
                 _slot1View.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
+                _slot1View.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
+                _slot1View.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
+                _slot1View.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
+
                 instance.RegisterCallback<MouseUpEvent>(evt =>
                 {
                     if (evt.button == 0) // Left click
@@ -76,6 +80,10 @@ namespace OutlandHaven.UIToolkit
                 _slot2View.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
                 _slot2View.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
+                _slot2View.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
+                _slot2View.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
+                _slot2View.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
+
                 instance.RegisterCallback<MouseUpEvent>(evt =>
                 {
                     if (evt.button == 0) // Left click
@@ -95,6 +103,10 @@ namespace OutlandHaven.UIToolkit
                 _resultSlotView.OnLocalRightClicked += (slot) => _uiInventoryEvents.OnItemRightClicked?.Invoke(slot);
                 _resultSlotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
                 _resultSlotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
+
+                _resultSlotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
+                _resultSlotView.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
+                _resultSlotView.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
             }
         }
 

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerEquipmentView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerEquipmentView.cs
@@ -122,6 +122,10 @@ namespace OutlandHaven.Inventory
             };
             slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
             slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
+
+            slotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
+            slotView.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
+            slotView.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
             slotView.Update(slotData);
 
             // Hide amount text label for equipment slots if it's there

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerInventoryView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerInventoryView.cs
@@ -104,6 +104,10 @@ namespace OutlandHaven.Inventory
                 slotView.OnLocalRightClicked += HandleMainInventoryRightClick;
                 slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
                 slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
+
+                slotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
+                slotView.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
+                slotView.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
                 slotView.Update(slotData);
 
                 // Click events are now handled natively inside InventorySlotView via PointerUpEvent

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/SalvageSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/SalvageSubView.cs
@@ -55,6 +55,10 @@ namespace OutlandHaven.UIToolkit
                 _inputSlotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
                 _inputSlotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
+                _inputSlotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
+                _inputSlotView.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
+                _inputSlotView.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
+
                 instance.RegisterCallback<MouseUpEvent>(evt =>
                 {
                     if (evt.button == 0) // Left click to remove item
@@ -74,6 +78,10 @@ namespace OutlandHaven.UIToolkit
                 _itemYieldView.OnLocalRightClicked += HandleItemRightClicked;
                 _itemYieldView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
                 _itemYieldView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
+
+                _itemYieldView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
+                _itemYieldView.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
+                _itemYieldView.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
             }
         }
 

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ShopSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ShopSubView.cs
@@ -117,6 +117,10 @@ namespace OutlandHaven.UIToolkit
                 slotView.OnLocalRightClicked += HandleShopSlotRightClicked;
                 slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
                 slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
+
+                slotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
+                slotView.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
+                slotView.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
                 var slotData = _shopContainer.LiveSlots[i];
 
                 slotView.Update(slotData);


### PR DESCRIPTION
Decouples `InventorySlotView` from direct dependencies by refactoring visual drag states onto the `UIInventoryEventsSO` event bus. 

### What
1. **Removed Singleton**: Stripped the `Instance` property from `UIDragManager` and switched to listening to global scriptable object events.
2. **Local Events**: Introduced granular visual events on the slots themselves (`OnLocalDragStarted`, `OnLocalDragUpdated`, `OnLocalDragStopped`).
3. **Translation Layer**: Parent views (e.g. `PlayerInventoryView`, `ForgeSubView`) now intercept the local component signals and pipe them onto the global bus (`OnGlobalDragStarted`, etc.), keeping the system highly decoupled.

### Why
To improve modularity, safety, and unit testability of individual UI views. Singleton calls from within template wrappers violated data segregation principles.

### Verification
- Verified code structure matches the event-bus patterns applied throughout the rest of the project.
- Checked git diff to ensure all subviews were targeted correctly and cleanly updated.

---
*PR created automatically by Jules for task [3675594256469904131](https://jules.google.com/task/3675594256469904131) started by @sourcereris*