### PR TITLE
✨ [Feature] Inventory Stack Splitting Support

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ---
 
+## [Current/Recent] - Inventory Stack Splitting Support
+- Added support for stack splitting using Shift-Click in the inventory drag-and-drop system. Players can now grab half a stack and drop it onto empty slots or stack it with other similar items.
+- Refactored `InventoryTransferManagerSO` logic to dictate transfer quantity based on the UI event instead of blindly consuming the entire source slot count.
+- Updated UI event pipeline (`UIInventoryEventsSO`, `InventorySlotView` and its subscribers) to pass `amountToMove` values.
+
 ## [Previous] - Decoupled Inventory Transfer Manager
 
 ### 1. Added SlotFilterType to InventorySlot

--- a/Toris/Assets/Scripts/Player/Player/Inventory/InventoryTransferManagerSO.cs
+++ b/Toris/Assets/Scripts/Player/Player/Inventory/InventoryTransferManagerSO.cs
@@ -25,10 +25,12 @@ namespace OutlandHaven.Inventory
             }
         }
 
-        private void HandleMoveItemRequest(InventoryManager sourceContainer, InventorySlot sourceSlot, InventoryManager targetContainer, InventorySlot targetSlot)
+        private void HandleMoveItemRequest(InventoryManager sourceContainer, InventorySlot sourceSlot, InventoryManager targetContainer, InventorySlot targetSlot, int amountToMove)
         {
             if (sourceContainer == null || sourceSlot == null || targetContainer == null || targetSlot == null) return;
             if (sourceSlot.IsEmpty) return; // Cannot move an empty slot
+            if (sourceSlot == targetSlot) return; // Cannot drop on the same slot
+            if (amountToMove <= 0) return; // Cannot move 0 or negative items
 
             // --- NEW: SMART VALIDATION ---
             // Ask the slot if it will accept the item. The Manager doesn't need to know WHY.
@@ -46,14 +48,16 @@ namespace OutlandHaven.Inventory
             }
             // ----------------------------
 
-            // 1. Is the target slot empty?
+            // Ensure we don't try to move more than we actually have
+            int actualAmount = Mathf.Min(amountToMove, sourceSlot.Count);
+
+            // 1. Is the target slot empty? (Full Move or Split)
             if (targetSlot.IsEmpty)
             {
-                // Move item directly
-                targetSlot.SetItem(sourceSlot.HeldItem, sourceSlot.Count);
-                sourceSlot.Clear();
+                targetSlot.SetItem(sourceSlot.HeldItem, actualAmount);
+                sourceSlot.DecreaseCount(actualAmount);
             }
-            // 2. Is the target slot holding the same stackable item type?
+            // 2. Is the target slot holding the same stackable item type? (Stack)
             else if (targetSlot.HeldItem.IsStackableWith(sourceSlot.HeldItem))
             {
                 int maxStackSize = targetSlot.HeldItem.BaseItem.MaxStackSize;
@@ -61,21 +65,34 @@ namespace OutlandHaven.Inventory
 
                 if (spaceInTarget > 0)
                 {
-                    int amountToMove = Mathf.Min(spaceInTarget, sourceSlot.Count);
+                    int amountWeCanMove = Mathf.Min(spaceInTarget, actualAmount);
 
-                    targetSlot.IncreaseCount(amountToMove);
-                    sourceSlot.DecreaseCount(amountToMove);
+                    targetSlot.IncreaseCount(amountWeCanMove);
+                    sourceSlot.DecreaseCount(amountWeCanMove);
                 }
             }
             // 3. Is the target slot holding a different item? (Swap)
             else
             {
+                // You cannot perform a swap if you are only moving a partial stack.
+                if (actualAmount != sourceSlot.Count)
+                {
+                    Debug.LogWarning("Drag Swap Failed: Cannot swap a partial stack with a different item.");
+                    return;
+                }
+
                 // Perform a direct swap of the item instances and counts
                 ItemInstance tempItem = targetSlot.HeldItem;
                 int tempCount = targetSlot.Count;
 
                 targetSlot.SetItem(sourceSlot.HeldItem, sourceSlot.Count);
                 sourceSlot.SetItem(tempItem, tempCount);
+            }
+
+            // Cleanup: If the source slot is now empty after a partial move or stack, clear it.
+            if (sourceSlot.Count <= 0)
+            {
+                sourceSlot.Clear();
             }
 
             // Fire events to notify listeners that inventories have changed

--- a/Toris/Assets/Scripts/UIToolkit/Template controlls/InventorySlotView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/Template controlls/InventorySlotView.cs
@@ -15,7 +15,7 @@ namespace OutlandHaven.Inventory
         private InventoryManager _owningContainer;
         public event Action<InventorySlot> OnLocalClicked;
         public event Action<InventorySlot> OnLocalRightClicked;
-        public event Action<InventoryManager, InventorySlot, InventoryManager, InventorySlot> OnLocalMoveItemRequested;
+        public event Action<InventoryManager, InventorySlot, InventoryManager, InventorySlot, int> OnLocalMoveItemRequested;
         public event Action<InventorySlot, string> OnLocalSelectForProcessingRequested;
 
         public event Action<Sprite, Vector2, Vector2> OnLocalDragStarted;
@@ -26,6 +26,7 @@ namespace OutlandHaven.Inventory
         private bool _isDragging = false;
         private Vector2 _dragStartPosition;
         private const float DragThreshold = 10f; // Pixels to move before initiating drag
+        private int _dragAmount = 0;
 
         public InventorySlotView(VisualElement root, InventoryManager owningContainer)
         {
@@ -109,6 +110,7 @@ namespace OutlandHaven.Inventory
                 if (distance >= DragThreshold)
                 {
                     _isDragging = true;
+                    _dragAmount = evt.shiftKey ? Mathf.CeilToInt(_slotData.Count / 2f) : _slotData.Count;
                     Vector2 iconSize = new Vector2(_icon.layout.width, _icon.layout.height);
                     OnLocalDragStarted?.Invoke(_slotData.HeldItem.BaseItem.Icon, evt.position, iconSize);
                 }
@@ -181,7 +183,7 @@ namespace OutlandHaven.Inventory
                         if (targetSlotData.Slot != _slotData || targetSlotData.Container != _owningContainer)
                         {
                             // Invoke the cross-container swap logic
-                            OnLocalMoveItemRequested?.Invoke(_owningContainer, _slotData, targetSlotData.Container, targetSlotData.Slot);
+                            OnLocalMoveItemRequested?.Invoke(_owningContainer, _slotData, targetSlotData.Container, targetSlotData.Slot, _dragAmount);
                             Debug.Log($"FIRING EVENT: Moving {_slotData.HeldItem.BaseItem.ItemName} to new slot.");
                         }
                     }

--- a/Toris/Assets/Scripts/UIToolkit/UI/Events/UIInventoryEventsSO.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/Events/UIInventoryEventsSO.cs
@@ -29,7 +29,7 @@ namespace OutlandHaven.Inventory
         public UnityAction<EquipmentSlot> OnRequestUnequip;
         
         [Header("Drag and Drop Events")]
-        public UnityAction<InventoryManager, InventorySlot, InventoryManager, InventorySlot> OnRequestMoveItem;
+        public UnityAction<InventoryManager, InventorySlot, InventoryManager, InventorySlot, int> OnRequestMoveItem;
 
         // Fired when an item is dropped onto a proxy visual slot (like Forge/Salvage)
         public UnityAction<InventorySlot, string> OnRequestSelectForProcessing;

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ForgeSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ForgeSubView.cs
@@ -52,7 +52,7 @@ namespace OutlandHaven.UIToolkit
 
                 _slot1View.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
                 _slot1View.OnLocalRightClicked += (slot) => _uiInventoryEvents.OnItemRightClicked?.Invoke(slot);
-                _slot1View.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                _slot1View.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 _slot1View.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 _slot1View.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
@@ -77,7 +77,7 @@ namespace OutlandHaven.UIToolkit
 
                 _slot2View.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
                 _slot2View.OnLocalRightClicked += (slot) => _uiInventoryEvents.OnItemRightClicked?.Invoke(slot);
-                _slot2View.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                _slot2View.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 _slot2View.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 _slot2View.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
@@ -101,7 +101,7 @@ namespace OutlandHaven.UIToolkit
 
                 _resultSlotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
                 _resultSlotView.OnLocalRightClicked += (slot) => _uiInventoryEvents.OnItemRightClicked?.Invoke(slot);
-                _resultSlotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                _resultSlotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 _resultSlotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 _resultSlotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerEquipmentView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerEquipmentView.cs
@@ -145,7 +145,7 @@ namespace OutlandHaven.Inventory
                     }
                 }
             };
-            slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+            slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove);
             slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
             slotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerInventoryView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerInventoryView.cs
@@ -109,7 +109,7 @@ namespace OutlandHaven.Inventory
 
                 slotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
                 slotView.OnLocalRightClicked += HandleMainInventoryRightClick;
-                slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove);
                 slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 slotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/SalvageSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/SalvageSubView.cs
@@ -52,7 +52,7 @@ namespace OutlandHaven.UIToolkit
 
                 _inputSlotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
                 _inputSlotView.OnLocalRightClicked += HandleItemRightClicked;
-                _inputSlotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                _inputSlotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 _inputSlotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 _inputSlotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
@@ -76,7 +76,7 @@ namespace OutlandHaven.UIToolkit
 
                 _itemYieldView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
                 _itemYieldView.OnLocalRightClicked += HandleItemRightClicked;
-                _itemYieldView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                _itemYieldView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 _itemYieldView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 _itemYieldView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ShopSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ShopSubView.cs
@@ -115,7 +115,7 @@ namespace OutlandHaven.UIToolkit
 
                 slotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
                 slotView.OnLocalRightClicked += HandleShopSlotRightClicked;
-                slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot);
+                slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 slotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);


### PR DESCRIPTION
This PR introduces stack splitting to the drag-and-drop inventory system.

🎯 What
- Holding 'Shift' while initiating a drag in the inventory will now calculate `amountToMove` as half the stack (`Mathf.CeilToInt(_slotData.Count / 2f)`).
- The intermediate `amountToMove` flows from `InventorySlotView` through `UIInventoryEventsSO` into `InventoryTransferManagerSO`.
- `InventoryTransferManagerSO` applies the logic correctly for partial moves, partial stacks, and blocks partial swaps.
- Specific crafting/shop UI logic bypasses this by hard-coding the `amountToMove` to `sourceSlot.Count`.

💡 Why
- Prevents the all-or-nothing requirement, massively improving standard UX paradigms for organizing loot.
- Preserves safety logic like same-slot checks or negative quantity checks.

---
*PR created automatically by Jules for task [17012286754117206356](https://jules.google.com/task/17012286754117206356) started by @sourcereris*