### PR TITLE
docs: Update architecture docs for targeted updates and drag-and-drop

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -1,4 +1,21 @@
-## [Current/Recent] - Skill Screen Architecture Implementation
+## [Current/Recent] - Documentation Update for Architecture Shifts
+This update refactors the core documentation to accurately reflect the current "production-ready" architecture of the inventory and drag-and-drop systems, moving away from prototyping implementations.
+
+### 1. Documented Shift from "Nuke" Redraw to Targeted Updates
+* Updated `Inventory_Event_System_Documentation.md` and `Drag_and_Drop_System_Documentation.md` to detail the removal of the parameterless `OnInventoryUpdated` event.
+* Added documentation for the new `OnSpecificSlotsUpdated(sourceSlot, targetSlot)` event.
+* Documented the `PlayerInventoryView`'s use of a Dictionary mapping for targeted UI rebuilds, eliminating GC spikes and enabling large-scale slot optimization.
+
+### 2. Documented Shift from Singleton Coupling to Event-Driven Modularity
+* Updated `UI_Interactions_Documentation.md` to remove outdated references to the rigid `UIDragManager.Instance` singleton pattern.
+* Documented the new decoupled, event-driven drag-and-drop system, highlighting how generic visual slots are now isolated and highly reusable across different contexts.
+
+### 3. Documented Shift to Quantity-Based Transactions
+* Updated `Inventory_Management_Documentation.md` and `UI_Interactions_Documentation.md` to explain the integration of an `amountToMove` integer.
+* Detailed the central validation logic within the transfer manager, emphasizing its authoritative role as a "bank" using `Mathf.Min` to calculate safe transfers, permit stack splitting, and explicitly block partial-stack swaps to preserve game economy.
+
+
+## [Previous] - Skill Screen Architecture Implementation
 This update introduces the foundational architecture for the Skill Screen, aligning with the project's MVC and Event Bus standards.
 
 ### 1. UI Layout & Styling (UXML/USS)
@@ -267,7 +284,7 @@ This update implements click-to-equip and click-to-unequip functionality for the
 
 ---
 
-## [Current/Recent] - Clean up Leftover Python Scripts
+## [Previous] - Clean up Leftover Python Scripts
 * Deleted leftover Python scripts (`*.py`) from the root directory that were accumulated during previous pull requests.
 
 ## [Previous] - Script Metadata Summaries

--- a/Toris/Assets/Documentation/Inventory_Event_System_Documentation.md
+++ b/Toris/Assets/Documentation/Inventory_Event_System_Documentation.md
@@ -38,32 +38,33 @@ The process of picking up a world item is handled through a sequence of interact
 - Contains a list of `InventorySlot` classes (which hold an `InventoryItemSO` reference and a count).
 - Contains the core logic for insertion (`AddItem`) and removal (`RemoveItem`).
   - **Stacking Logic**: `AddItem` first checks if the item exists in an incomplete stack before filling an empty slot.
-- **The Crucial Event Dispatch**: Whenever `AddItem` or `RemoveItem` successfully mutates the state of the slots, the container invokes `_uiInventoryEvents.OnInventoryUpdated.Invoke()`.
+- **The Crucial Event Dispatch**: Whenever `AddItem` or `RemoveItem` successfully mutates the state of the slots, the container invokes `_uiInventoryEvents.OnSpecificSlotsUpdated.Invoke(sourceSlot, targetSlot)`.
 
 ## 3. UI Reactivity (The Event System)
 
-The UI needs to know when to redraw itself, but it should not constantly poll the `InventoryManager`.
+The UI needs to know when to redraw itself, but it should not constantly poll the `InventoryManager`. To ensure high performance and scalability, the UI employs targeted updates rather than full redraws.
 
 ### `UIInventoryEventsSO`
 This ScriptableObject acts as the central event bus specifically for inventory and economy-related UI updates.
 
 **Key Events:**
-*   `OnInventoryUpdated`: A simple `UnityAction` fired whenever any item is added or removed from the main player container. The Player's `InventoryView` listens to this to trigger a visual rebuild.
+*   `OnSpecificSlotsUpdated(InventorySlot sourceSlot, InventorySlot targetSlot)`: Fired whenever specific items are moved, added, or removed. The `PlayerInventoryView` listens to this event to trigger a visual rebuild only for the exact slots that were modified, avoiding massive Managed Heap allocations and GC spikes.
+*   `OnRequestMoveItem(InventorySlot source, InventorySlot target, int amountToMove)`: Dispatched when a UI action (like drag-and-drop or shift-click) attempts to transfer an item, including the explicit quantity requested to move.
 *   `OnShopInventoryUpdated`: Fired when a vendor's stock changes. Shop UI views listen to this.
-*   `OnRequestBuy(InventoryItemSO, int)`: Dispatched by UI Views when a player attempts to buy an item. A central `ShopManager` listens to this to process the transaction.
-*   `OnRequestSell(InventoryItemSO, int)`: Dispatched by UI views to sell an item.
+*   `OnRequestBuy(InventoryItemSO, int amount)`: Dispatched by UI Views when a player attempts to buy an item, carrying the requested quantity.
+*   `OnRequestSell(InventoryItemSO, int amount)`: Dispatched by UI views to sell an item.
 *   `(int)`: Fired when player gold increases/decreases. Currency displays listen to this.
 
 ## 4. UI View Lifecycle Example (PlayerInventoryView)
 
 1.  **Opening the UI**: A separate system (like `InputManager` or an NPC interaction) fires `UIEventsSO.OnRequestOpen(ScreenType.Inventory, containerData)`.
-2.  **Setup & Bind**: The `InventoryScreenController` instantiates the `PlayerInventoryView`. During the view's `Show()` or `Setup()` phase, it subscribes to `UIInventoryEventsSO.OnInventoryUpdated`.
+2.  **Setup & Bind**: The `InventoryScreenController` instantiates the `PlayerInventoryView`. During the view's `Show()` or `Setup()` phase, it subscribes to `UIInventoryEventsSO.OnSpecificSlotsUpdated`. The view utilizes a Dictionary to map backing data slots to visual elements.
 3.  **The Event Loop**:
     *   Player presses "E" near a sword (`ItemPickEventSO.OnItemPick` fired).
-    *   Sword added to `InventoryManager`.
-    *   `InventoryManager` fires `UIInventoryEventsSO.OnInventoryUpdated`.
-    *   `PlayerInventoryView` hears the event, clears its visual slots, and rebuilds them based on the new authoritative state of the `InventoryManager`.
-4.  **Cleanup**: When the UI is closed (`Hide()`), the view *must* unsubscribe from `OnInventoryUpdated` to prevent memory leaks and null reference errors when the UI is not active.
+    *   Sword added to `InventoryManager` at a specific index.
+    *   `InventoryManager` fires `UIInventoryEventsSO.OnSpecificSlotsUpdated(modifiedSlot, null)`.
+    *   `PlayerInventoryView` hears the event and rebuilds *only* the visual representation mapped to `modifiedSlot`.
+4.  **Cleanup**: When the UI is closed (`Hide()`), the view *must* unsubscribe from `OnSpecificSlotsUpdated` to prevent memory leaks and null reference errors when the UI is not active.
 
 ## Summary Diagram
 
@@ -77,8 +78,8 @@ This ScriptableObject acts as the central event bus specifically for inventory a
                                               [InventoryManager.AddItem()]
                                                          | (If successful, mutates data)
                                                          v
-                                              fires [UIInventoryEventsSO.OnInventoryUpdated]
+                                              fires [UIInventoryEventsSO.OnSpecificSlotsUpdated(slot, null)]
                                                          |
                                                          v
-                                              [PlayerInventoryView] (Hears event, redraws slots)
+                                              [PlayerInventoryView] (Hears event, redraws ONLY the modified slot via Dictionary lookup)
 ```

--- a/Toris/Assets/Documentation/Inventory_Management_Documentation.md
+++ b/Toris/Assets/Documentation/Inventory_Management_Documentation.md
@@ -17,13 +17,17 @@ The player's inventory (and NPC inventories) are managed by dedicated `Scriptabl
 *   **Core Logic:**
     *   **Initialization (`OnEnable` & `OnValidate`)**: Ensures the `Slots` list is populated up to `SlotCount` with empty `InventorySlot` objects. It enforces basic constraints, like setting a minimum quantity of 1 if an item is manually placed via the inspector.
     *   **Player Registration**: When a player's `InventoryManager` activates (`OnEnable`), it registers itself to a global state (e.g., `GameSessionSO.PlayerInventory`) if `ContainerBlueprint != null && ContainerBlueprint.AssociatedView == ScreenType.Inventory`.
+    *   **Quantity-Based Transactions (The "Bank" Authority):** Moving away from simple binary (all-or-nothing) transfers, the system now enforces precise quantity control.
+        *   **Actual Amount Calculation:** Uses `Mathf.Min(amountToMove, maxSpaceInTargetSlot, currentStackInSourceSlot)` to explicitly calculate how many items can legally transfer. This prevents overfilling and logic errors.
+        *   **Stack Splitting:** Permits transferring partial amounts from one slot to another, satisfying standard RPG quality-of-life expectations.
+        *   **Blocking Partial-Stack Swaps:** When dragging an item onto a different item type, the transaction manager blocks partial swaps to protect the game economy from deletion bugs or duplication glitches, functioning as an authoritative validation layer before moving data.
     *   **Adding Items (`AddItem`)**:
         1.  *First Pass:* Iterates through existing slots to find stacks of the *same* item (`IsStackableWith`). It fills those stacks up to the `MaxStackSize` defined in the item's blueprint.
         2.  *Second Pass:* If quantity remains, it finds the first empty slot (`IsEmpty`) and places the remainder there.
-        3.  *Events:* Returns `true` if successful, invoking `UIInventoryEventsSO.OnInventoryUpdated`.
+        3.  *Events:* Returns `true` if successful, invoking targeted `UIInventoryEventsSO.OnSpecificSlotsUpdated` events rather than global redraws.
     *   **Removing Items (`RemoveItem`)**:
         1.  *First Pass:* Calculates the total available quantity across all stacks of that item to verify sufficiency.
-        2.  *Second Pass:* Iterates through and decreases stack counts, clearing slots if they hit 0, until the requested quantity is removed. Invokes `OnInventoryUpdated`.
+        2.  *Second Pass:* Iterates through and decreases stack counts, clearing slots if they hit 0, until the requested quantity is removed. Invokes targeted `OnSpecificSlotsUpdated` events.
 
 ## 2. Inventory Slot Logic
 

--- a/Toris/Assets/Documentation/Item_Architecture/Drag_and_Drop_System_Documentation.md
+++ b/Toris/Assets/Documentation/Item_Architecture/Drag_and_Drop_System_Documentation.md
@@ -1,0 +1,44 @@
+# Drag and Drop System Architecture
+
+This document details the newly refactored event-driven Drag and Drop system implemented within Outland Haven, moving away from rigid singleton-based visual management to a highly decoupled and scalable pipeline.
+
+## Overview
+
+The core shift in the drag-and-drop architecture replaces the use of rigid singletons (such as `UIDragManager.Instance`) within individual visual slots. Instead, the architecture relies on an event-driven pattern and controller delegation. Visual slots do not handle logic or directly command the visual hierarchy; they only emit state changes, allowing higher-level controllers or managers to act on those intentions.
+
+## Architectural Shifts
+
+### 1. Event-Driven Modularity
+Previously, UI views were tightly coupled to global singletons, making them difficult to reuse across different systems (like a hotbar or a skill tree) or environments where the singleton might be absent.
+
+**The Solution:**
+`InventorySlotView` and other interactive visual elements are now completely "dumb" and isolated. They translate low-level UI Toolkit hardware events into generic semantic events and broadcast them.
+
+For instance, when a drag gesture is detected:
+*   Instead of calling `UIDragManager.Instance.StartDrag()`, the view fires an event or defers to an injected controller pattern.
+*   This ensures that dropping the script into another environment or project will not throw null reference exceptions looking for an inventory-specific drag manager. It greatly improves the stability of scene transitions.
+
+### 2. Targeted Updates over "Nuke" Redraws
+When an item completes a drag-and-drop operation (a transfer or swap), the original prototype logic forced a complete UI rebuild by broadcasting a parameterless `OnInventoryUpdated` event.
+
+**The Solution:**
+The system now broadcasts a highly specific `OnSpecificSlotsUpdated(sourceSlot, targetSlot)`. The active UI view uses a Dictionary map to rebuild only the visual representation of the exact two slots involved in the transaction. This eliminates GC spikes and allows the inventory grid to scale massively without dropping frames. It also enables future potential for targeted animations.
+
+### 3. Quantity-Based Transactions
+Transfers have been upgraded from basic binary (all-or-nothing) actions to fully featured quantity-based transactions.
+
+**The Solution:**
+An `amountToMove` integer is injected into the entire pipeline.
+*   **User Intent:** Input listeners (e.g., detecting the Shift key during a drag) determine the requested quantity.
+*   **The Global Event:** The request event `OnRequestMoveItem` passes the source, target, and the requested `amountToMove`.
+*   **The Arbitration Layer:** The centralized arbitrator (`InventoryTransferManagerSO`) processes the rules. It uses `Mathf.Min(amountToMove, targetSpace, sourceQuantity)` to calculate the safe bounds of the transfer, gracefully handling stack splitting.
+*   **Safety Net:** It explicitly blocks partial-stack swaps (trying to move 5 arrows onto a stack of 2 swords) to protect the underlying game economy from duplication or deletion bugs.
+
+## Technical Flow Summary
+
+1.  **Input:** User clicks and drags an item in an `InventorySlotView`.
+2.  **Threshold:** The `PointerMoveEvent` verifies a pixel threshold has been met before confirming the action as a drag.
+3.  **Visual Layer:** Through an injected controller or an event broadcast, a "Ghost" visual icon is spawned in a dedicated, root-level `#Drag_Layer` (with `pickingMode = PickingMode.Ignore`).
+4.  **Drop Intention:** The user releases the pointer over a valid target. An event like `OnRequestMoveItem(source, target, amount)` is dispatched.
+5.  **Execution:** The authoritative logic manager calculates the `Mathf.Min` valid transfer and mutates the data.
+6.  **Targeted Redraw:** The data container dispatches `OnSpecificSlotsUpdated(source, target)`. The UI view looks up those specific slots in its mapping Dictionary and updates only their visual state.

--- a/Toris/Assets/Documentation/UI_Interactions_Documentation.md
+++ b/Toris/Assets/Documentation/UI_Interactions_Documentation.md
@@ -14,7 +14,7 @@ To keep the UI views strictly separated from game logic, raw hardware inputs (e.
 Examples of abstracted events include:
 *   `OnItemClicked(InventorySlot slotData)`: Typically fired on a standard left-click (pointer up).
 *   `OnItemRightClicked(InventorySlot slotData)`: Typically fired on a standard right-click (pointer up with right mouse button). Used for auto-fill in crafting or quick-sell in shops.
-*   `OnRequestMoveItem(InventorySlot source, InventorySlot target)`: Emitted when a drag-and-drop operation successfully finishes over a valid target.
+*   `OnRequestMoveItem(InventorySlot source, InventorySlot target, int amountToMove)`: Emitted when a drag-and-drop operation successfully finishes over a valid target, explicitly stating the quantity to move (e.g., accounting for Shift key stack splitting).
 
 ## 2. Drag-and-Drop Implementation
 
@@ -34,7 +34,7 @@ A crucial rule for drag-and-drop implementations is the use of a **Drag Threshol
 ### The "Ghost" Icon and Drag Layer
 To prevent clipping issues where a dragged item disappears behind other UI panels (due to flexbox layout constraints or standard hierarchy drawing order):
 *   **Dedicated Root Layer:** A temporary "ghost" visual element is instantiated representing the dragged item.
-*   **Global Position:** This ghost icon is placed in a dedicated root-level `#Drag_Layer` managed by a separate `UIDragManager` injected at runtime. It is *not* a child of the original slot.
+*   **Global Position:** This ghost icon is placed in a dedicated root-level `#Drag_Layer` managed by an injected event-driven pattern. Visual slots no longer hard-reference global singletons (like `UIDragManager.Instance`) but instead rely on event broadcasts or controller delegation.
 *   **Picking Mode:** Crucially, the ghost icon must have `pickingMode = PickingMode.Ignore` set programmatically. If it does not, the ghost icon itself will intercept the `PointerUpEvent` raycasts, making it impossible to drop the item onto another slot.
 
 ## 3. Context Overrides and Generic Views
@@ -49,7 +49,7 @@ Context-specific windows (like `ShopSubView`, `SalvageSubView`, `ForgeSubView`) 
 
 When an item is dropped from one inventory (e.g., player) to another (e.g., chest), it involves two separate `InventoryManager` instances.
 *   **Arbitration:** To prevent hard-coupling between containers, cross-container transfers are handled by a centralized arbitrator (e.g., `InventoryTransferManagerSO`).
-*   **Execution:** This manager listens to the global `OnRequestMoveItem` event, taking both the full source context and target context. It evaluates the rules (can these merge? is there space?) and manipulates the respective managers accordingly.
+*   **Execution:** This manager listens to the global `OnRequestMoveItem` event, taking both the full source context, target context, and the `amountToMove`. It evaluates the rules (can these merge? is there space?), calculates the `actualAmount` via `Mathf.Min` logic to prevent overfilling and block partial-stack swap bugs, and then manipulates the respective managers accordingly.
 
 ## 5. Cleaning Up Event Listeners
 


### PR DESCRIPTION
This PR updates the core architecture documentation to accurately reflect the newly implemented, production-ready systems. It focuses on three major shifts: the transition from "Nuke" redraws to targeted dictionary-based updates, the shift from rigid singletons to an event-driven Drag-and-Drop architecture, and the upgrade to fully featured quantity-based transactions. Outdated references to `OnInventoryUpdated` and `UIDragManager` have been completely purged, and a dedicated document has been created for the new drag-and-drop mechanics.

---
*PR created automatically by Jules for task [5658725651171824583](https://jules.google.com/task/5658725651171824583) started by @sourcereris*