### PR TITLE
Fix compilation error in UIInventoryEventsSO.cs

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -494,6 +494,14 @@ This update implements click-to-equip and click-to-unequip functionality for the
 * Renamed `Item_System_Architecture_Documentation.md` to `Item_Architecture_Documentation.md` and `UI_System_Documentation.md` to `UI_Architecture_Documentation.md` for naming consistency.
 * Fixed typos in `General_Scripting_Conventions.md` pathing examples (e.g., `ScritableObjects` to `ScriptableObjects`).
 
+## [Current/Recent] - UI Inventory Events Compilation Fix
+This update resolves a compilation error in `UIInventoryEventsSO.cs` caused by exceeding the maximum number of type arguments supported by `UnityAction`.
+
+### 1. Fixed `OnRequestMoveItem` Delegate
+* Changed the `OnRequestMoveItem` event from `UnityAction` to `System.Action` to support 5 type arguments (`InventoryManager`, `InventorySlot`, `InventoryManager`, `InventorySlot`, `int`).
+
+---
+
 ## [Unreleased]
 ### Changed
 - **UI Architecture:** Fixed vertical scrollbar bug in the player inventory UI (`PlayerInventory.uxml`) by forcing the `vertical-scroller-visibility` to `Hidden`, correctly addressing the layout calculation bug on subsequent openings for the fixed 21-slot grid.

--- a/Toris/Assets/Scripts/UIToolkit/UI/Events/UIInventoryEventsSO.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/Events/UIInventoryEventsSO.cs
@@ -29,7 +29,7 @@ namespace OutlandHaven.Inventory
         public UnityAction<EquipmentSlot> OnRequestUnequip;
         
         [Header("Drag and Drop Events")]
-        public UnityAction<InventoryManager, InventorySlot, InventoryManager, InventorySlot, int> OnRequestMoveItem;
+        public System.Action<InventoryManager, InventorySlot, InventoryManager, InventorySlot, int> OnRequestMoveItem;
 
         // Fired when an item is dropped onto a proxy visual slot (like Forge/Salvage)
         public UnityAction<InventorySlot, string> OnRequestSelectForProcessing;


### PR DESCRIPTION
This commit fixes the `CS0308: The non-generic type 'UnityAction' cannot be used with type arguments` compilation error in `UIInventoryEventsSO.cs`. `UnityAction` only supports up to 4 type parameters, but `OnRequestMoveItem` required 5. It was changed to `System.Action` which supports up to 16. The CHANGELOG was also updated accordingly.

---
*PR created automatically by Jules for task [12886062446155195117](https://jules.google.com/task/12886062446155195117) started by @sourcereris*