### PR TITLE
fix: Enforce Item Type Validation for Drag-and-Drop Equipment Transfers

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -1,4 +1,19 @@
-## [Current/Recent] - Refactored Drag-and-Drop to Event-Driven Architecture
+## [Current/Recent] - Enforce Item Type Validation for Drag-and-Drop Equipment Transfers
+
+### 1. Data-Driven Slot Filters
+* Extended `InventoryContainerSO` with an optional `PredefinedFilters` array of `SlotFilterType`.
+* Updated `InventorySlot` constructor to accept and set a default `SlotFilterType`.
+* Updated `InventoryManager` to initialize live slots using the predefined filters from its blueprint.
+
+### 2. Configured Equipment Filters
+* Updated `Container_Player-Equipments.asset` to map its 5 slots to specific filters: Head, Chest, Legs, Arms, Weapon. This ensures invalid items are blocked by `InventoryTransferManagerSO` during drag-and-drop.
+
+### 3. Error Handling
+* Added out-of-bounds error logging in `PlayerEquipmentController.ProcessSlot()` to catch configuration mismatches.
+
+---
+
+## [Previous] - Refactored Drag-and-Drop to Event-Driven Architecture
 
 ### 1. Removed Singleton Dependency
 * Removed the Singleton pattern from `UIDragManager`, completely decoupling it from `InventorySlotView`.
@@ -14,7 +29,7 @@
 
 ---
 
-## [Current/Recent] - Inventory Stack Splitting Support
+## [Previous] - Inventory Stack Splitting Support
 - Added support for stack splitting using Shift-Click in the inventory drag-and-drop system. Players can now grab half a stack and drop it onto empty slots or stack it with other similar items.
 - Refactored `InventoryTransferManagerSO` logic to dictate transfer quantity based on the UI event instead of blindly consuming the entire source slot count.
 - Updated UI event pipeline (`UIInventoryEventsSO`, `InventorySlotView` and its subscribers) to pass `amountToMove` values.

--- a/Toris/Assets/Resources/GameData/InventoryContainers/Container_Player-Equipments.asset
+++ b/Toris/Assets/Resources/GameData/InventoryContainers/Container_Player-Equipments.asset
@@ -14,3 +14,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::OutlandHaven.Inventory.InventoryContainerSO
   SlotCount: 5
   AssociatedView: 3
+  PredefinedFilters:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4

--- a/Toris/Assets/Scripts/Player/Player/Equipment/PlayerEquipmentController.cs
+++ b/Toris/Assets/Scripts/Player/Player/Equipment/PlayerEquipmentController.cs
@@ -57,7 +57,10 @@ public class PlayerEquipmentController : MonoBehaviour
     private void ProcessSlot(int index, EquipmentSlot slotType)
     {
         if (index >= _equipmentInventory.LiveSlots.Count)
+        {
+            Debug.LogError($"[PlayerEquipmentController] Index {index} is out of bounds for Equipment Inventory! Expected at least {index + 1} slots.");
             return;
+        }
 
         InventorySlot slotData = _equipmentInventory.LiveSlots[index];
         ItemInstance currentItemInSlot = slotData.IsEmpty ? null : slotData.HeldItem;

--- a/Toris/Assets/Scripts/Player/Player/Inventory/InventoryManager.cs
+++ b/Toris/Assets/Scripts/Player/Player/Inventory/InventoryManager.cs
@@ -24,7 +24,11 @@ namespace OutlandHaven.Inventory
                 // Ensure LiveSlots count exactly matches the Blueprint's SlotCount
                 while (LiveSlots.Count < ContainerBlueprint.SlotCount)
                 {
-                    LiveSlots.Add(new InventorySlot());
+                    int index = LiveSlots.Count;
+                    SlotFilterType filter = (ContainerBlueprint.PredefinedFilters != null && index < ContainerBlueprint.PredefinedFilters.Length)
+                        ? ContainerBlueprint.PredefinedFilters[index]
+                        : SlotFilterType.Any;
+                    LiveSlots.Add(new InventorySlot(filter));
                 }
                 while (LiveSlots.Count > ContainerBlueprint.SlotCount)
                 {
@@ -46,7 +50,11 @@ namespace OutlandHaven.Inventory
 
                 while (LiveSlots.Count < ContainerBlueprint.SlotCount)
                 {
-                    LiveSlots.Add(new InventorySlot());
+                    int index = LiveSlots.Count;
+                    SlotFilterType filter = (ContainerBlueprint.PredefinedFilters != null && index < ContainerBlueprint.PredefinedFilters.Length)
+                        ? ContainerBlueprint.PredefinedFilters[index]
+                        : SlotFilterType.Any;
+                    LiveSlots.Add(new InventorySlot(filter));
                 }
                 while (LiveSlots.Count > ContainerBlueprint.SlotCount)
                 {

--- a/Toris/Assets/Scripts/UIToolkit/ScriptableObjects/InventoryContainerSO.cs
+++ b/Toris/Assets/Scripts/UIToolkit/ScriptableObjects/InventoryContainerSO.cs
@@ -8,5 +8,7 @@ namespace OutlandHaven.Inventory
     {
         public int SlotCount = 20;
         public ScreenType AssociatedView = ScreenType.None;
+        [Tooltip("Optional predefined filters for specific slots by index.")]
+        public SlotFilterType[] PredefinedFilters;
     }
 }

--- a/Toris/Assets/Scripts/UIToolkit/Template controlls/InventorySlot.cs
+++ b/Toris/Assets/Scripts/UIToolkit/Template controlls/InventorySlot.cs
@@ -21,11 +21,11 @@ namespace OutlandHaven.Inventory
 
         public bool IsEmpty => HeldItem == null || HeldItem.BaseItem == null;
 
-        public InventorySlot()
+        public InventorySlot(SlotFilterType filter = SlotFilterType.Any)
         {
             HeldItem = new ItemInstance();
             Count = 0;
-            AllowedFilter = SlotFilterType.Any;
+            AllowedFilter = filter;
         }
 
         public bool CanAccept(ItemInstance item)


### PR DESCRIPTION
Currently, the inventory system successfully prevents non-equippable items from being equipped via context click, but a loophole exists in the drag-and-drop pipeline. Players can manually drag a non-equippable item directly into a physical slot within the `PlayerEquipmentView`, and the system accepts it. 

The bug is caused by `InventoryManager` initializing all slots with `SlotFilterType.Any` by default, regardless of the container. While `PlayerEquipmentController` assumes a specific layout for the equipment inventory, it never updates the `AllowedFilter` of these slots in the data layer to match this layout. Consequently, the slots accept any item during the `CanAccept` validation step.

**Fix:**
This PR enforces item validation directly in the data layer using a data-driven approach:
- Added a new `PredefinedFilters` array of `SlotFilterType` to `InventoryContainerSO` to define the baseline constraints for specific slots.
- Updated `InventoryManager` to initialize live slots using these predefined filters instead of defaulting to `Any`.
- Configured the Equipment container asset to map its 5 slots to specific filters (Head, Chest, Legs, Arms, Weapon).
- Added out-of-bounds error logging in `PlayerEquipmentController.ProcessSlot()` to prevent silent failures if definitions misalign.

---
*PR created automatically by Jules for task [14433390017724774589](https://jules.google.com/task/14433390017724774589) started by @sourcereris*