### PR TITLE
Fix click and right-click interactions in auxiliary UI views

### DIFF
--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -525,7 +525,21 @@ This update implements click-to-equip and click-to-unequip functionality for the
 * Renamed `Item_System_Architecture_Documentation.md` to `Item_Architecture_Documentation.md` and `UI_System_Documentation.md` to `UI_Architecture_Documentation.md` for naming consistency.
 * Fixed typos in `General_Scripting_Conventions.md` pathing examples (e.g., `ScritableObjects` to `ScriptableObjects`).
 
-## [Current/Recent] - UI Inventory Events Compilation Fix
+## [Current/Recent] - Resolved Broken Click Events in Auxiliary Views
+This update resolves issues where left-click and right-click events were not functioning correctly or triggering unintended behaviors in auxiliary views like Forge and Salvage after the drag-and-drop refactor.
+
+### 1. Updated Contextual Right-Click Logic
+* Added an `InventoryInteractionContext.Forge` state.
+* `PlayerInventoryView` now routes right-clicks on main inventory items to a new `OnRequestSendToForge` event when the Forge context is active, standardizing the universal fast-action interaction pattern.
+
+### 2. Fixed Proxy Slot Clearing
+* Removed legacy `MouseUpEvent` bindings on ignored UI Toolkit roots in `ForgeSubView` and `SalvageSubView`.
+* Disconnected proxy slots (`salvage-input`, `forge-slot-1`, `forge-slot-2`) from the global `OnItemClicked` event bus to prevent infinite proxy-spawning loops.
+* Bound both left-click and right-click actions on proxy slots directly to local `ClearSlot` methods, allowing players to easily remove items from the Forge/Salvage areas.
+
+---
+
+## [Previous] - UI Inventory Events Compilation Fix
 This update resolves a compilation error in `UIInventoryEventsSO.cs` caused by exceeding the maximum number of type arguments supported by `UnityAction`.
 
 ### 1. Fixed `OnRequestMoveItem` Delegate

--- a/Toris/Assets/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Documentation/Changelog/CHANGELOG.md
@@ -1,4 +1,18 @@
-## [Current/Recent] - Documentation Update for Architecture Shifts
+## [Current/Recent] - Resolved Broken Purchasing Functionality in Shop
+This update fixes the shop purchase pipeline which failed due to deprecated input handling and overly rigid bulk-buy validation.
+
+### 1. Fixed Modifier Key Input in UI Toolkit
+* Replaced legacy `Input.GetKey()` polling in `ShopSubView.cs` which could silently fail.
+* Added a new `OnLocalRightClickedWithShift` event in `InventorySlotView.cs` to cleanly pass the `evt.shiftKey` state from the pointer payload directly to parent views, ensuring robust UI event decoupling.
+
+### 2. Improved Transaction Validation
+* Modified `ShopManagerSO.HandleRequestBuy` to automatically clamp the requested purchase quantity against the shop's actual available stock.
+* Clamped the purchase quantity against the player's total affordable amount.
+* This prevents bulk-buy attempts (e.g., requesting 10 items) from instantly failing when the shop only holds 2 items or the player only has gold for 4.
+
+---
+
+## [Previous] - Documentation Update for Architecture Shifts
 This update refactors the core documentation to accurately reflect the current "production-ready" architecture of the inventory and drag-and-drop systems, moving away from prototyping implementations.
 
 ### 1. Documented Shift from "Nuke" Redraw to Targeted Updates

--- a/Toris/Assets/Documentation/Script_Descriptions/InventorySlotView.md
+++ b/Toris/Assets/Documentation/Script_Descriptions/InventorySlotView.md
@@ -9,8 +9,8 @@ Core Logic:
   * `Dispose()`: Unregisters pointer callbacks to prevent memory leaks.
 
 Dependency Graph:
-* Upstream: Requires `UnityEngine.UIElements`, `InventorySlot`, `InventoryManager`, `UIInventoryEventsSO`, `UIDragManager`.
-* Downstream: Managed by Parent Views (e.g., `PlayerInventoryView`, `PlayerEquipmentView`).
+* Upstream: Requires `UnityEngine.UIElements`, `InventorySlot`, `InventoryManager`.
+* Downstream: Exposes events (`OnLocalClicked`, `OnLocalRightClicked`, `OnLocalDragStarted`, etc.) consumed by Parent Views (e.g., `PlayerInventoryView`, `PlayerEquipmentView`).
 
 Data Schema:
 * `VisualElement _root`: Reference to the root slot container element.
@@ -18,11 +18,10 @@ Data Schema:
 * `Label _qtyLabel`: Reference to the item quantity label.
 * `InventorySlot _slotData`: Cached reference to the bound slot data.
 * `InventoryManager _owningContainer`: Reference to the container managing the slot.
-* `UIInventoryEventsSO _uiInventoryEvents`: Reference to the event channel for UI interactions.
 * `bool _isDragging`: Tracks active drag state.
 * `Vector2 _dragStartPosition`: Tracks the pointer position where the click originated.
 
 Side Effects & Lifecycle:
 * Initialization: Manual initialization via constructor (binds UI elements and registers callbacks).
 * Allocations: Instantiates `SlotDropData` during `Update` if not using a proxy ID.
-* Lifecycle: Subscribes to `PointerDownEvent`, `PointerMoveEvent`, `PointerUpEvent` on the root element. Triggers external events on `UIInventoryEventsSO`. Must be explicitly disposed via `Dispose()`. Modifies `pickingMode` of UI elements.
+* Lifecycle: Subscribes to `PointerDownEvent`, `PointerMoveEvent`, `PointerUpEvent` on the root element. Triggers local events (e.g., `OnLocalRightClicked(slotData, evt.shiftKey)`). Must be explicitly disposed via `Dispose()`. Modifies `pickingMode` of UI elements and manages internal pointer capture constraints.

--- a/Toris/Assets/Scripts/UIToolkit/ScriptableObjects/ShopManagerSO.cs
+++ b/Toris/Assets/Scripts/UIToolkit/ScriptableObjects/ShopManagerSO.cs
@@ -64,9 +64,38 @@ namespace OutlandHaven.UIToolkit
             if (PlayerAnchor == null || !PlayerAnchor.IsReady) return;
             if (CurrentShopInventory == null) return;
 
+            // Clamp quantity to how much stock the shop actually has to prevent bulk buy failures
+            int shopStock = 0;
+            foreach (var slot in CurrentShopInventory.LiveSlots)
+            {
+                if (slot != null && !slot.IsEmpty && slot.HeldItem.IsStackableWith(item))
+                {
+                    shopStock += slot.Count;
+                }
+            }
+
+            quantity = Mathf.Min(quantity, shopStock);
+
+            if (quantity <= 0) return; // Shop is out of stock
+
+            // Clamp quantity to how much gold the player has
+            int affordableQuantity = item.BaseItem.GoldValue > 0
+                ? PlayerAnchor.Instance.CurrentGold / item.BaseItem.GoldValue
+                : quantity; // If free, player can afford whatever the shop has
+
+            quantity = Mathf.Min(quantity, affordableQuantity);
+
+            if (quantity <= 0)
+            {
+#if UNITY_EDITOR
+                Debug.LogWarning("Not enough gold to buy even one item.");
+#endif
+                return;
+            }
+
             int totalCost = item.BaseItem.GoldValue * quantity;
 
-            // Check if player has enough gold
+            // Check if player has enough gold (redundant due to clamping, but safe)
             if (PlayerAnchor.Instance.CurrentGold >= totalCost)
             {
                 // First check if the shop actually has enough items to sell
@@ -103,12 +132,6 @@ namespace OutlandHaven.UIToolkit
                     Debug.LogWarning("Shop does not have enough stock of the requested item.");
 #endif
                 }
-            }
-            else
-            {
-#if UNITY_EDITOR
-                Debug.LogWarning("Not enough gold to buy item.");
-#endif
             }
         }
 

--- a/Toris/Assets/Scripts/UIToolkit/Template controlls/InventorySlotView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/Template controlls/InventorySlotView.cs
@@ -15,6 +15,7 @@ namespace OutlandHaven.Inventory
         private InventoryManager _owningContainer;
         public event Action<InventorySlot> OnLocalClicked;
         public event Action<InventorySlot> OnLocalRightClicked;
+        public event Action<InventorySlot, bool> OnLocalRightClickedWithShift;
         public event Action<InventoryManager, InventorySlot, InventoryManager, InventorySlot, int> OnLocalMoveItemRequested;
         public event Action<InventorySlot, string> OnLocalSelectForProcessingRequested;
 
@@ -145,6 +146,7 @@ namespace OutlandHaven.Inventory
                 if (_slotData != null && !_slotData.IsEmpty)
                 {
                     OnLocalRightClicked?.Invoke(_slotData);
+                    OnLocalRightClickedWithShift?.Invoke(_slotData, evt.shiftKey);
                 }
                 return;
             }

--- a/Toris/Assets/Scripts/UIToolkit/UI/Events/InventoryInteractionContext.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/Events/InventoryInteractionContext.cs
@@ -4,6 +4,7 @@ namespace OutlandHaven.Inventory
     {
         Normal,
         Shop,
-        Salvage
+        Salvage,
+        Forge
     }
 }

--- a/Toris/Assets/Scripts/UIToolkit/UI/Events/UIInventoryEventsSO.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/Events/UIInventoryEventsSO.cs
@@ -22,6 +22,7 @@ namespace OutlandHaven.Inventory
         public UnityAction<InventorySlot> OnItemRightClicked;
         public UnityAction<InventorySlot, SalvageType> OnRequestSalvage;
         public UnityAction<InventorySlot, InventorySlot> OnRequestForge;
+        public UnityAction<InventorySlot> OnRequestSendToForge;
 
         [Header("Player Inventory Actions")]
         public UnityAction<InventorySlot> OnRequestEquip;

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ForgeSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ForgeSubView.cs
@@ -50,22 +50,14 @@ namespace OutlandHaven.UIToolkit
                 _slot1Container.Add(instance);
                 _slot1View = new InventorySlotView(instance, null);
 
-                _slot1View.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
-                _slot1View.OnLocalRightClicked += (slot) => _uiInventoryEvents.OnItemRightClicked?.Invoke(slot);
+                _slot1View.OnLocalClicked += (slot) => ClearSlot1();
+                _slot1View.OnLocalRightClicked += (slot) => ClearSlot1();
                 _slot1View.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 _slot1View.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 _slot1View.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
                 _slot1View.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
                 _slot1View.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
-
-                instance.RegisterCallback<MouseUpEvent>(evt =>
-                {
-                    if (evt.button == 0) // Left click
-                    {
-                        ClearSlot1();
-                    }
-                });
             }
 
             if (_slot2Container != null)
@@ -75,22 +67,14 @@ namespace OutlandHaven.UIToolkit
                 _slot2Container.Add(instance);
                 _slot2View = new InventorySlotView(instance, null);
 
-                _slot2View.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
-                _slot2View.OnLocalRightClicked += (slot) => _uiInventoryEvents.OnItemRightClicked?.Invoke(slot);
+                _slot2View.OnLocalClicked += (slot) => ClearSlot2();
+                _slot2View.OnLocalRightClicked += (slot) => ClearSlot2();
                 _slot2View.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 _slot2View.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 _slot2View.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
                 _slot2View.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
                 _slot2View.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
-
-                instance.RegisterCallback<MouseUpEvent>(evt =>
-                {
-                    if (evt.button == 0) // Left click
-                    {
-                        ClearSlot2();
-                    }
-                });
             }
 
             if (_resultSlotContainer != null)
@@ -99,8 +83,8 @@ namespace OutlandHaven.UIToolkit
                 _resultSlotContainer.Add(instance);
                 _resultSlotView = new InventorySlotView(instance, null);
 
-                _resultSlotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
-                _resultSlotView.OnLocalRightClicked += (slot) => _uiInventoryEvents.OnItemRightClicked?.Invoke(slot);
+                _resultSlotView.OnLocalClicked += (slot) => { /* Result slot is display-only or handle differently */ };
+                _resultSlotView.OnLocalRightClicked += (slot) => { /* Result slot is display-only or handle differently */ };
                 _resultSlotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 _resultSlotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
@@ -120,9 +104,10 @@ namespace OutlandHaven.UIToolkit
         public override void Show()
         {
             base.Show();
+            _uiInventoryEvents?.OnInteractionContextChanged?.Invoke(InventoryInteractionContext.Forge);
             if (!_eventsBound && _uiInventoryEvents != null)
             {
-                _uiInventoryEvents.OnItemClicked += HandleItemClicked;
+                _uiInventoryEvents.OnRequestSendToForge += HandleItemClicked;
                 _uiInventoryEvents.OnRequestSelectForProcessing += HandleProxyDrop;
                 _eventsBound = true;
             }
@@ -135,10 +120,11 @@ namespace OutlandHaven.UIToolkit
 
         public override void Hide()
         {
+            _uiInventoryEvents?.OnInteractionContextChanged?.Invoke(InventoryInteractionContext.Normal);
             base.Hide();
             if (_eventsBound && _uiInventoryEvents != null)
             {
-                _uiInventoryEvents.OnItemClicked -= HandleItemClicked;
+                _uiInventoryEvents.OnRequestSendToForge -= HandleItemClicked;
                 _uiInventoryEvents.OnRequestSelectForProcessing -= HandleProxyDrop;
                 _eventsBound = false;
             }
@@ -266,7 +252,7 @@ namespace OutlandHaven.UIToolkit
         {
             if (_eventsBound && _uiInventoryEvents != null)
             {
-                _uiInventoryEvents.OnItemClicked -= HandleItemClicked;
+                _uiInventoryEvents.OnRequestSendToForge -= HandleItemClicked;
                 _uiInventoryEvents.OnRequestSelectForProcessing -= HandleProxyDrop;
                 _eventsBound = false;
             }

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerInventoryView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerInventoryView.cs
@@ -153,6 +153,9 @@ namespace OutlandHaven.Inventory
                 case InventoryInteractionContext.Salvage:
                     _uiInventoryEvents.OnRequestSalvage?.Invoke(dataSlot, SalvageType.Material); // default salvage type
                     break;
+                case InventoryInteractionContext.Forge:
+                    _uiInventoryEvents.OnRequestSendToForge?.Invoke(dataSlot);
+                    break;
                 case InventoryInteractionContext.Normal:
                 default:
                     _uiInventoryEvents.OnRequestEquip?.Invoke(dataSlot);

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/SalvageSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/SalvageSubView.cs
@@ -50,22 +50,14 @@ namespace OutlandHaven.UIToolkit
                 _inputSlotContainer.Add(instance);
                 _inputSlotView = new InventorySlotView(instance, null);
 
-                _inputSlotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
-                _inputSlotView.OnLocalRightClicked += HandleItemRightClicked;
+                _inputSlotView.OnLocalClicked += (slot) => ClearInputSlot();
+                _inputSlotView.OnLocalRightClicked += (slot) => ClearInputSlot();
                 _inputSlotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 _inputSlotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
                 _inputSlotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
                 _inputSlotView.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
                 _inputSlotView.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
-
-                instance.RegisterCallback<MouseUpEvent>(evt =>
-                {
-                    if (evt.button == 0) // Left click to remove item
-                    {
-                        ClearInputSlot();
-                    }
-                });
             }
 
             if (_itemYieldContainer != null)
@@ -74,8 +66,8 @@ namespace OutlandHaven.UIToolkit
                 _itemYieldContainer.Add(instance);
                 _itemYieldView = new InventorySlotView(instance, null);
 
-                _itemYieldView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
-                _itemYieldView.OnLocalRightClicked += HandleItemRightClicked;
+                _itemYieldView.OnLocalClicked += (slot) => { /* display only */ };
+                _itemYieldView.OnLocalRightClicked += (slot) => { /* display only */ };
                 _itemYieldView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 _itemYieldView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
@@ -157,24 +149,6 @@ namespace OutlandHaven.UIToolkit
             UpdateYieldVisuals();
         }
 
-        private void HandleItemRightClicked(InventorySlot slot)
-        {
-            if (slot == null || slot.IsEmpty) return;
-
-            // If we right clicked the same item that's in the salvage proxy slot (or a dummy),
-            // or if we right clicked the proxy slot itself (if that's ever possible)
-            if (_cachedSourceSlot == slot)
-            {
-                ClearInputSlot();
-                return;
-            }
-
-            // Otherwise, set it as the proxy input slot if it's salvageable
-            if (_salvageManager != null && _salvageManager.CanSalvage(slot.HeldItem.BaseItem))
-            {
-                HandleItemClicked(slot);
-            }
-        }
 
         private void ClearInputSlot()
         {

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ShopSubView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/ShopSubView.cs
@@ -113,8 +113,10 @@ namespace OutlandHaven.UIToolkit
 
                 var slotView = new InventorySlotView(slotInstance, _shopContainer);
 
-                slotView.OnLocalClicked += (slot) => _uiInventoryEvents.OnItemClicked?.Invoke(slot);
-                slotView.OnLocalRightClicked += HandleShopSlotRightClicked;
+                // Left clicks in the shop currently do not have a defined action (e.g. details panel).
+                // We disconnect them from the global bus to prevent unintended side effects in other systems.
+                slotView.OnLocalClicked += (slot) => { /* Reserved for future selection/details logic */ };
+                slotView.OnLocalRightClickedWithShift += HandleShopSlotRightClicked;
                 slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, sourceSlot.Count);
                 slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
 
@@ -129,11 +131,10 @@ namespace OutlandHaven.UIToolkit
         }
 
 
-        private void HandleShopSlotRightClicked(InventorySlot slotData)
+        private void HandleShopSlotRightClicked(InventorySlot slotData, bool isShiftHeld)
         {
             if (slotData == null || slotData.IsEmpty) return;
 
-            bool isShiftHeld = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
             int amount = isShiftHeld ? BULK_BUY_AMOUNT : 1;
 
             _uiInventoryEvents?.OnRequestBuy?.Invoke(slotData.HeldItem, amount);


### PR DESCRIPTION
Resolves the issue where click events were broken in auxiliary views (Forge, Salvage, Shop) after the drag-and-drop refactor.

### 🎯 What
* **Universal Contextual Action:** Introduced `InventoryInteractionContext.Forge`. When the Smith UI is open, right-clicking items in the player inventory now properly triggers `OnRequestSendToForge` to seamlessly transfer the items to the crafting interface, standardizing right-click interactions across all contexts (Shop/Sell, Salvage/Dismantle, Forge/Send).
* **Proxy Slot Fixes:**
  * Disconnected proxy visual slots from the global `OnItemClicked` bus. Previously, clicking on a populated proxy slot would mistakenly fire a global "Add Item" event, duplicating items.
  * Mapped local left-click and right-click events on these proxies directly to their respective `ClearSlot` functions, providing an intuitive way for players to remove items from crafting tables.
  * Removed deprecated and ineffective `MouseUpEvent` legacy listeners on root elements that were ignoring picking raycasts.
* **Changelog Updated:** Detailed the fixes under `## [Current/Recent] - Resolved Broken Click Events in Auxiliary Views`.

### 💡 Why
* To restore the standard user experience for equipment management where drag-and-drop works alongside quick right-click actions.
* To prevent broken behaviors like proxy-spawning loops when accidentally clicking placed items.
* To ensure UI components correctly respond to the newly refactored event architecture without legacy code bloat.

### ✨ Result
* Left-clicks correctly handle dragging or basic selection depending on threshold.
* Right-clicks on items dynamically adapt to the active UI mode (selling, salvaging, sending to forge, or equipping).
* Clicking items currently sitting in Forge or Salvage slots instantly returns them (clears the slot).

---
*PR created automatically by Jules for task [3465877835081356787](https://jules.google.com/task/3465877835081356787) started by @sourcereris*