### PR TITLE
✨ Implement Player Stats Panel in Inventory UI

### DIFF
--- a/Toris/Assets/Scripts/Player/Player/View/PlayerHUDBridge.cs
+++ b/Toris/Assets/Scripts/Player/Player/View/PlayerHUDBridge.cs
@@ -21,12 +21,14 @@ public class PlayerHUDBridge : MonoBehaviour
     public event Action<PlayerStatusEffectType> OnStatusApplied;
     public event Action<PlayerStatusEffectType> OnStatusRemoved;
     public event Action<PlayerStatusEffectType, float> OnStatusDamageTick;
+    public event Action<PlayerResolvedEffects> OnResolvedEffectsChanged;
 
     public float CurrentHealth => _playerStats != null ? _playerStats.currentHP : 0f;
     public float MaxHealth => _playerStats != null ? _playerStats.maxHP : 0f;
 
     public float CurrentStamina => _playerStats != null ? _playerStats.currentStamina : 0f;
     public float MaxStamina => _playerStats != null ? _playerStats.maxStamina : 0f;
+    public PlayerResolvedEffects ResolvedEffects => _playerStats != null ? _playerStats.ResolvedEffects : PlayerResolvedEffects.CreateDefault();
 
     public int CurrentLevel => _playerProgression != null ? _playerProgression.CurrentLevel : 1;
     public float CurrentExperience => _playerProgression != null ? _playerProgression.CurrentExperience : 0f;
@@ -59,6 +61,7 @@ public class PlayerHUDBridge : MonoBehaviour
         {
             _playerStats.OnHealthChanged += HandleHealthChanged;
             _playerStats.OnStaminaChanged += HandleStaminaChanged;
+            _playerStats.OnResolvedEffectsChanged += HandleResolvedEffectsChanged;
         }
 
         if (_playerProgression != null)
@@ -81,6 +84,7 @@ public class PlayerHUDBridge : MonoBehaviour
         {
             _playerStats.OnHealthChanged -= HandleHealthChanged;
             _playerStats.OnStaminaChanged -= HandleStaminaChanged;
+            _playerStats.OnResolvedEffectsChanged -= HandleResolvedEffectsChanged;
         }
 
         if (_playerProgression != null)
@@ -108,6 +112,7 @@ public class PlayerHUDBridge : MonoBehaviour
         {
             OnHealthChanged?.Invoke(_playerStats.currentHP, _playerStats.maxHP);
             OnStaminaChanged?.Invoke(_playerStats.currentStamina, _playerStats.maxStamina);
+            OnResolvedEffectsChanged?.Invoke(_playerStats.ResolvedEffects);
         }
 
         if (_playerProgression != null)
@@ -125,6 +130,11 @@ public class PlayerHUDBridge : MonoBehaviour
     private void HandleStaminaChanged(float current, float max)
     {
         OnStaminaChanged?.Invoke(current, max);
+    }
+
+    private void HandleResolvedEffectsChanged(PlayerResolvedEffects resolvedEffects)
+    {
+        OnResolvedEffectsChanged?.Invoke(resolvedEffects);
     }
 
     private void HandleLevelChanged(int level, float experience)

--- a/Toris/Assets/Scripts/UIToolkit/UI/Controllers/InventoryScreenController.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/Controllers/InventoryScreenController.cs
@@ -17,6 +17,9 @@ namespace OutlandHaven.Inventory
         [Tooltip("The InventoryManager configured to act as the equipment container (e.g. 5 slots).")]
         [SerializeField] private InventoryManager _equipmentInventory;
 
+        [Header("Player Data")]
+        [SerializeField] private PlayerHUDBridge _playerHUDBridge;
+
         private PlayerInventoryView _view;
         private UIManager _uiManager;
 
@@ -40,7 +43,7 @@ namespace OutlandHaven.Inventory
             
             inventoryInstance.style.flexGrow = 1; // Make it fill the parent container
 
-            _view = new PlayerInventoryView(inventoryInstance, _slotTemplate, _gameSession, _uiEvents, _uiInventoryEvents, _equipmentInventory);
+            _view = new PlayerInventoryView(inventoryInstance, _slotTemplate, _gameSession, _uiEvents, _uiInventoryEvents, _equipmentInventory, _playerHUDBridge);
             _view.Initialize();
 
             // Register to the RIGHT zone

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerInventoryView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerInventoryView.cs
@@ -19,19 +19,22 @@ namespace OutlandHaven.Inventory
         // UI Containers
         private VisualElement _playerGrid;
         private PlayerEquipmentView _equipmentView;
+        private PlayerStatsView _statsView;
+        private PlayerHUDBridge _hudBridge;
         private InventoryManager _equipmentInventory;
 
         private UIInventoryEventsSO _uiInventoryEvents;
         private bool _eventsBound = false;
         private InventoryInteractionContext _currentContext = InventoryInteractionContext.Normal;
 
-        public PlayerInventoryView(VisualElement topElement, VisualTreeAsset slotTemplate, GameSessionSO session, UIEventsSO uiEvents, UIInventoryEventsSO uiInventoryEvents, InventoryManager equipmentInventory = null)
+        public PlayerInventoryView(VisualElement topElement, VisualTreeAsset slotTemplate, GameSessionSO session, UIEventsSO uiEvents, UIInventoryEventsSO uiInventoryEvents, InventoryManager equipmentInventory = null, PlayerHUDBridge hudBridge = null)
             : base(topElement, uiEvents)
         {
             _slotTemplate = slotTemplate;
             _gameSession = session;
             _uiInventoryEvents = uiInventoryEvents;
             _equipmentInventory = equipmentInventory;
+            _hudBridge = hudBridge;
         }
 
         public override void Initialize()
@@ -39,6 +42,8 @@ namespace OutlandHaven.Inventory
             base.Initialize();
             _equipmentView = new PlayerEquipmentView(m_TopElement, _slotTemplate, _uiInventoryEvents);
             _equipmentView.Initialize();
+            _statsView = new PlayerStatsView(m_TopElement);
+            _statsView.Initialize();
         }
 
         public override void Show()
@@ -53,6 +58,7 @@ namespace OutlandHaven.Inventory
                 _eventsBound = true;
             }
             _equipmentView?.Show();
+            _statsView?.Show();
         }
 
         public override void Hide()
@@ -67,6 +73,7 @@ namespace OutlandHaven.Inventory
                 _eventsBound = false;
             }
             _equipmentView?.Hide();
+            _statsView?.Hide();
         }
 
         protected override void SetVisualElements()
@@ -85,6 +92,7 @@ namespace OutlandHaven.Inventory
             // Refresh Player Inventory (Always)
             RefreshGrid(_playerGrid, _gameSession.PlayerInventory); 
             _equipmentView?.Setup(_equipmentInventory);
+            _statsView?.Setup(_hudBridge);
         }
 
         private void RefreshGrid(VisualElement gridRoot, InventoryManager data)
@@ -179,6 +187,7 @@ namespace OutlandHaven.Inventory
                 _eventsBound = false;
             }
             _equipmentView?.Dispose();
+            _statsView?.Dispose();
 
             base.Dispose();
         }

--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerStatsView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/PlayerStatsView.cs
@@ -1,0 +1,95 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+using System;
+
+namespace OutlandHaven.Inventory
+{
+    public class PlayerStatsView : IDisposable
+    {
+        private VisualElement _topElement;
+        private PlayerHUDBridge _hudBridge;
+
+        private Label _statMaxHealth;
+        private Label _statMaxStamina;
+        private Label _statMoveSpeed;
+        private Label _statOutgoingDamage;
+
+        private bool _eventsBound = false;
+
+        public PlayerStatsView(VisualElement topElement)
+        {
+            _topElement = topElement;
+            SetVisualElements();
+        }
+
+        private void SetVisualElements()
+        {
+            _statMaxHealth = _topElement.Q<Label>("stat-maxHealth");
+            _statMaxStamina = _topElement.Q<Label>("stat-maxStamina");
+            _statMoveSpeed = _topElement.Q<Label>("stat-moveSpeed");
+            _statOutgoingDamage = _topElement.Q<Label>("stat-outgoingDamage");
+        }
+
+        public void Initialize()
+        {
+            // Usually anything initial related goes here
+        }
+
+        public void Setup(PlayerHUDBridge hudBridge)
+        {
+            _hudBridge = hudBridge;
+            RefreshStats();
+        }
+
+        public void Show()
+        {
+            if (!_eventsBound && _hudBridge != null)
+            {
+                _hudBridge.OnResolvedEffectsChanged += HandleResolvedEffectsChanged;
+                _eventsBound = true;
+            }
+            RefreshStats();
+        }
+
+        public void Hide()
+        {
+            if (_eventsBound && _hudBridge != null)
+            {
+                _hudBridge.OnResolvedEffectsChanged -= HandleResolvedEffectsChanged;
+                _eventsBound = false;
+            }
+        }
+
+        private void HandleResolvedEffectsChanged(PlayerResolvedEffects effects)
+        {
+            UpdateLabels(effects);
+        }
+
+        private void RefreshStats()
+        {
+            if (_hudBridge == null) return;
+
+            UpdateLabels(_hudBridge.ResolvedEffects);
+        }
+
+        private void UpdateLabels(PlayerResolvedEffects effects)
+        {
+            if (_statMaxHealth != null)
+                _statMaxHealth.text = $"Max Health: {effects.maxHealth:F0}";
+
+            if (_statMaxStamina != null)
+                _statMaxStamina.text = $"Max Stamina: {effects.maxStamina:F0}";
+
+            if (_statMoveSpeed != null)
+                _statMoveSpeed.text = $"Move Speed: {effects.moveSpeedMultiplier:F2}x";
+
+            if (_statOutgoingDamage != null)
+                _statOutgoingDamage.text = $"Damage: {effects.outgoingDamageMultiplier:F2}x";
+        }
+
+        public void Dispose()
+        {
+            Hide();
+        }
+    }
+}

--- a/Toris/Assets/UI_Toolkit/UXMLs/PlayerInventory.uxml
+++ b/Toris/Assets/UI_Toolkit/UXMLs/PlayerInventory.uxml
@@ -11,10 +11,10 @@
                 <ui:VisualElement name="Stats__Panel" class="player-stats-panel">
                     <ui:Label text="Stats" class="panel-title"/>
                     <ui:ScrollView class="stats-scroll-view">
-                        <ui:Label text="STR: 25" class="stat-label"/>
-                        <ui:Label text="DEX: 40" class="stat-label"/>
-                        <ui:Label text="INT: 15" class="stat-label"/>
-                        <ui:Label text="VIT: 200/200" class="stat-label"/>
+                        <ui:Label name="stat-maxHealth" text="Max Health: 0" class="stat-label"/>
+                        <ui:Label name="stat-maxStamina" text="Max Stamina: 0" class="stat-label"/>
+                        <ui:Label name="stat-moveSpeed" text="Move Speed: 1.0" class="stat-label"/>
+                        <ui:Label name="stat-outgoingDamage" text="Outgoing Damage: 1.0" class="stat-label"/>
                     </ui:ScrollView>
                 </ui:VisualElement>
                 


### PR DESCRIPTION
This PR implements the functionality to map live player stats (Max Health, Max Stamina, Move Speed, Outgoing Damage) into the new Stats Panel inside the Player Inventory UI.

By exposing the `PlayerResolvedEffects` structure through the existing `PlayerHUDBridge`, the new `PlayerStatsView` subview correctly parses and renders the live stats without directly coupling UI to core gameplay logic. The UXML structure was updated with proper specific names (`name="..."`) instead of just classes, allowing efficient component querying (`root.Q<Label>("name")`). The top-level `InventoryScreenController` exposes the `PlayerHUDBridge` reference as a `SerializeField` to adhere to the project's dependency injection style and avoid runtime lookup overheads.

---
*PR created automatically by Jules for task [311427857137639607](https://jules.google.com/task/311427857137639607) started by @sourcereris*