### PR TITLE
✨ [feature] add PlayerPotionView for inventory quick-slots

### DIFF
--- a/Toris/Assets/Scripts/UIToolkit/UI/UIViews/Player_Inventory/PlayerPotionView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/UIViews/Player_Inventory/PlayerPotionView.cs
@@ -1,0 +1,135 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+using System;
+using System.Collections.Generic;
+using OutlandHaven.UIToolkit;
+
+namespace OutlandHaven.Inventory
+{
+    public class PlayerPotionView : IDisposable
+    {
+        private VisualElement _topElement;
+        private VisualTreeAsset _slotTemplate;
+        private UIInventoryEventsSO _uiInventoryEvents;
+
+        private Dictionary<InventorySlot, InventorySlotView> _potionSlotDictionary = new Dictionary<InventorySlot, InventorySlotView>();
+
+        private VisualElement _slotPotion1Container;
+        private VisualElement _slotPotion2Container;
+
+        private InventoryManager _potionInventory;
+        private bool _eventsBound = false;
+
+        public PlayerPotionView(VisualElement topElement, VisualTreeAsset slotTemplate, UIInventoryEventsSO uiInventoryEvents)
+        {
+            _topElement = topElement;
+            _slotTemplate = slotTemplate;
+            _uiInventoryEvents = uiInventoryEvents;
+
+            SetVisualElements();
+        }
+
+        private void SetVisualElements()
+        {
+            _slotPotion1Container = _topElement.Q<VisualElement>("slot-potion-1");
+            _slotPotion2Container = _topElement.Q<VisualElement>("slot-potion-2");
+        }
+
+        public void Initialize()
+        {
+        }
+
+        public void Setup(InventoryManager potionInventory)
+        {
+            _potionInventory = potionInventory;
+            RefreshSlots();
+        }
+
+        public void Show()
+        {
+            if (!_eventsBound && _uiInventoryEvents != null)
+            {
+                _uiInventoryEvents.OnInventoryUpdated += OnInventoryUpdated;
+                _uiInventoryEvents.OnSpecificSlotsUpdated += HandleSpecificSlotsUpdated;
+                _eventsBound = true;
+            }
+            RefreshSlots();
+        }
+
+        public void Hide()
+        {
+            if (_eventsBound && _uiInventoryEvents != null)
+            {
+                _uiInventoryEvents.OnInventoryUpdated -= OnInventoryUpdated;
+                _uiInventoryEvents.OnSpecificSlotsUpdated -= HandleSpecificSlotsUpdated;
+                _eventsBound = false;
+            }
+        }
+
+        private void OnInventoryUpdated()
+        {
+            RefreshSlots();
+        }
+
+        private void HandleSpecificSlotsUpdated(InventorySlot sourceSlot, InventorySlot targetSlot)
+        {
+            if (sourceSlot != null && _potionSlotDictionary.TryGetValue(sourceSlot, out var sourceView))
+            {
+                sourceView.Update(sourceSlot);
+            }
+
+            if (targetSlot != null && _potionSlotDictionary.TryGetValue(targetSlot, out var targetView))
+            {
+                targetView.Update(targetSlot);
+            }
+        }
+
+        private void RefreshSlots()
+        {
+            if (_potionInventory == null || _potionInventory.LiveSlots == null) return;
+
+            _potionSlotDictionary.Clear();
+
+            RefreshSingleSlot(0, _slotPotion1Container);
+            RefreshSingleSlot(1, _slotPotion2Container);
+        }
+
+        private void RefreshSingleSlot(int index, VisualElement containerRoot)
+        {
+            if (containerRoot == null) return;
+
+            containerRoot.Clear();
+
+            if (index >= _potionInventory.LiveSlots.Count)
+                return;
+
+            InventorySlot slotData = _potionInventory.LiveSlots[index];
+
+            TemplateContainer slotInstance = _slotTemplate.Instantiate();
+            slotInstance.AddToClassList("item-slot--potion");
+            containerRoot.Add(slotInstance);
+
+            var slotView = new InventorySlotView(slotInstance, _potionInventory);
+
+            slotView.OnLocalMoveItemRequested += (sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove) => _uiInventoryEvents.OnRequestMoveItem?.Invoke(sourceContainer, sourceSlot, targetContainer, targetSlot, amountToMove);
+            slotView.OnLocalSelectForProcessingRequested += (slot, proxyID) => _uiInventoryEvents.OnRequestSelectForProcessing?.Invoke(slot, proxyID);
+
+            slotView.OnLocalDragStarted += (sprite, pos, size) => _uiInventoryEvents.OnGlobalDragStarted?.Invoke(sprite, pos, size);
+            slotView.OnLocalDragUpdated += (pos) => _uiInventoryEvents.OnGlobalDragUpdated?.Invoke(pos);
+            slotView.OnLocalDragStopped += () => _uiInventoryEvents.OnGlobalDragStopped?.Invoke();
+            slotView.Update(slotData);
+
+            _potionSlotDictionary.Add(slotData, slotView);
+        }
+
+        public void Dispose()
+        {
+            if (_eventsBound && _uiInventoryEvents != null)
+            {
+                _uiInventoryEvents.OnInventoryUpdated -= OnInventoryUpdated;
+                _uiInventoryEvents.OnSpecificSlotsUpdated -= HandleSpecificSlotsUpdated;
+                _eventsBound = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
🎯 What
Implemented the `PlayerPotionView.cs` script to handle the visual instantiation and state synchronization of consumable potion quick-slots. It is structured identically to `PlayerEquipmentView.cs`.

💡 Why
To support potion quick-slots in the inventory UI while strictly adhering to the "Architecture of Restraint" and decoupled MVP pattern established in `UI_ARCHITECTURE_RULESET.md` and `Equipment_System_Documentation.md`.

✅ Verification
- Ensured `IDisposable` pattern is followed.
- Confirmed constructor takes `VisualElement`, `VisualTreeAsset`, and `UIInventoryEventsSO`.
- UXML elements `slot-potion-1` and `slot-potion-2` are queried.
- `slotInstance.AddToClassList("item-slot--potion")` is applied immediately after instantiation.
- Events map exactly to the standard `PlayerEquipmentView` wiring, routing `OnLocalSelectForProcessingRequested` for right-click interaction.

✨ Result
A clean, completely "dumb" UI view that visually renders the potion inventory manager without hardcoding custom consumable interaction logic, allowing backend systems to process events.

---
*PR created automatically by Jules for task [11694835272783499936](https://jules.google.com/task/11694835272783499936) started by @sourcereris*