### PR TITLE
Expansion of Quest Fact System

### DIFF
--- a/Toris/Assets/Scripts/Quest/Dialogue/QuestFact.cs
+++ b/Toris/Assets/Scripts/Quest/Dialogue/QuestFact.cs
@@ -52,4 +52,29 @@ public struct QuestFact
     {
         return new QuestFact(QuestFactType.ClearSite, exactId, typeOrTag, amount, contextId);
     }
+
+    public static QuestFact BuyItem(string exactId, string typeOrTag = "", int amount = 1, string contextId = "")
+    {
+        return new QuestFact(QuestFactType.BuyItem, exactId, typeOrTag, amount, contextId);
+    }
+
+    public static QuestFact SellItem(string exactId, string typeOrTag = "", int amount = 1, string contextId = "")
+    {
+        return new QuestFact(QuestFactType.SellItem, exactId, typeOrTag, amount, contextId);
+    }
+
+    public static QuestFact LevelReached(string exactId, string typeOrTag = "", int amount = 1, string contextId = "")
+    {
+        return new QuestFact(QuestFactType.LevelReached, exactId, typeOrTag, amount, contextId);
+    }
+
+    public static QuestFact EnterBiome(string exactId, string typeOrTag = "", int amount = 1, string contextId = "")
+    {
+        return new QuestFact(QuestFactType.EnterBiome, exactId, typeOrTag, amount, contextId);
+    }
+
+    public static QuestFact InteractWorldObject(string exactId, string typeOrTag = "", int amount = 1, string contextId = "")
+    {
+        return new QuestFact(QuestFactType.InteractWorldObject, exactId, typeOrTag, amount, contextId);
+    }
 }

--- a/Toris/Assets/Scripts/Quest/Dialogue/QuestFactType.cs
+++ b/Toris/Assets/Scripts/Quest/Dialogue/QuestFactType.cs
@@ -13,5 +13,15 @@ public enum QuestFactType
     /// <summary>A site, encounter, or authored objective was cleared.</summary>
     ClearSite = 5,
     /// <summary>The player interacted with an NPC.</summary>
-    InteractNpc = 6
+    InteractNpc = 6,
+    /// <summary>The player bought an item.</summary>
+    BuyItem = 7,
+    /// <summary>The player sold an item.</summary>
+    SellItem = 8,
+    /// <summary>The player reached a certain level.</summary>
+    LevelReached = 9,
+    /// <summary>The player entered a biome.</summary>
+    EnterBiome = 10,
+    /// <summary>The player interacted with a world object.</summary>
+    InteractWorldObject = 11
 }

--- a/Toris/Assets/Scripts/Quest/Quest_Documentation.md
+++ b/Toris/Assets/Scripts/Quest/Quest_Documentation.md
@@ -490,7 +490,7 @@ Current Toris-side bridge components:
 - `PixelCrushersQuestProgressMapper`
 - `PixelCrushersQuestRewardAdapter`
 - `QuestFact`
-- `QuestFactType`
+- `QuestFactType` (Supported: Kill, PickUp, EnterScene, VisitSite, ClearSite, InteractNpc, BuyItem, SellItem, LevelReached, EnterBiome, InteractWorldObject)
 - `QuestFactProgressRuleSetSO`
 - `PixelCrushersQuestRewardSetSO`
 - `QuestFactSceneReporter`


### PR DESCRIPTION
Expanded the quest fact system to support more gameplay events as outlined in the documentation. The bridge between Toris gameplay and Pixel Crushers now supports BuyItem, SellItem, LevelReached, EnterBiome, and InteractWorldObject facts, which can be mapped to quest progress using existing ScriptableObject rule sets without further code changes. All work was strictly contained within the Assets/Scripts/Quest directory.

---
*PR created automatically by Jules for task [13817167176880409539](https://jules.google.com/task/13817167176880409539) started by @thameeeh*