### PR TITLE
🧹 [Fix] Main Menu Save Slot visibility in UI Toolkit

### DIFF
--- a/Toris/Assets/Scripts/UIToolkit/UI/Main Menu/MainMenuController.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/Main Menu/MainMenuController.cs
@@ -60,9 +60,7 @@ public class MainMenuController : MonoBehaviour
         for (int i = 1; i <= 3; i++)
         {
             TemplateContainer slotInstance = _saveSlotTemplate.Instantiate();
-            slotInstance.style.flexShrink = 0;
-            slotInstance.style.width = 280;
-            slotInstance.style.height = 180;
+            slotInstance.AddToClassList("save-slot-wrapper");
 
             SaveSlotView slotView = new SaveSlotView(slotInstance, i);
             slotView.Initialize();

--- a/Toris/Assets/Scripts/UIToolkit/UI/Main Menu/MainMenuView.cs
+++ b/Toris/Assets/Scripts/UIToolkit/UI/Main Menu/MainMenuView.cs
@@ -48,13 +48,13 @@ public class MainMenuView : GameView
     // ADDED: Let the View handle adding elements to its own DOM
     public void AddSaveSlot(VisualElement slotElement)
     {
-        if (_saveSlotsContainer != null) _saveSlotsContainer.Add(slotElement);
+        if (_saveSlotsContainer != null) _saveSlotsContainer.contentContainer.Add(slotElement);
     }
 
     // ADDED: Let the View handle clearing its own DOM
     public void ClearSaveSlots()
     {
-        if (_saveSlotsContainer != null) _saveSlotsContainer.Clear();
+        if (_saveSlotsContainer != null) _saveSlotsContainer.contentContainer.Clear();
     }
 
     // ADDED: MVP compliant method to change UI state[cite: 7]

--- a/Toris/Assets/UI_Toolkit/USS/Main_Menu/SaveSlot.uss
+++ b/Toris/Assets/UI_Toolkit/USS/Main_Menu/SaveSlot.uss
@@ -37,3 +37,9 @@
     color: var(--color-border-highlight); /* Golden color for emphasized stats[cite: 17] */
     -unity-font-style: bold;
 }
+/* --- Save Slot Wrapper --- */
+.save-slot-wrapper {
+    flex-shrink: 0;
+    width: 280px;
+    height: 180px;
+}


### PR DESCRIPTION
🎯 What
Fixed an issue where instantiated Save Slot cards were not rendering inside the ScrollView on the Main Menu. They were generating click events and console logs, but visually failing.

💡 Why
- Modern UI Toolkit sometimes fails to route dynamically instantiated elements properly into ScrollView bounds.
- We needed to remove C# inline styling from the controller and move it securely into the USS engine to comply with architecture rules.

✅ Verification
- `MainMenuView` correctly pushes `.Add()` into `.contentContainer.Add()`
- `SaveSlot.uss` holds the rigid layout constraints to prevent zero-height squishing.
- `MainMenuController` successfully uses `AddToClassList` in place of inline modifications.

✨ Result
Save slots securely and correctly display inside the list format on the main menu without breaking styling rules.

---
*PR created automatically by Jules for task [6852647243188085670](https://jules.google.com/task/6852647243188085670) started by @sourcereris*