### PR TITLE
Fix potion and equipment inventory loading across scenes

### DIFF
--- a/Toris/Assets/Scripts/Player/Player/Inventory/InventoryManager.cs
+++ b/Toris/Assets/Scripts/Player/Player/Inventory/InventoryManager.cs
@@ -132,6 +132,10 @@ namespace OutlandHaven.Inventory
                 {
                     GlobalSession.PlayerEquipment = this; // Bind the equipment!
                 }
+                else if (IsPotionContainer())
+                {
+                    GlobalSession.PlayerPotionInventory = this;
+                }
             }
         }
 
@@ -149,6 +153,10 @@ namespace OutlandHaven.Inventory
                 else if (LooksLikeEquipmentContainer() && GlobalSession.PlayerEquipment == this)
                 {
                     GlobalSession.PlayerEquipment = null; // Unbind the equipment!
+                }
+                else if (IsPotionContainer() && GlobalSession.PlayerPotionInventory == this)
+                {
+                    GlobalSession.PlayerPotionInventory = null;
                 }
             }
         }
@@ -323,6 +331,11 @@ namespace OutlandHaven.Inventory
                 type = "Equipment";
                 restored = GlobalSession.TryApplyEquipmentInventoryState(this);
             }
+            else if (IsPotionContainer())
+            {
+                type = "Potion";
+                restored = GlobalSession.TryApplyPotionInventoryState(this);
+            }
 
             if (restored)
             {
@@ -352,6 +365,11 @@ namespace OutlandHaven.Inventory
                 Debug.Log($"[Inventory] CAPTURING Equipment state for '{gameObject.name}' into GameSession snapshot.");
                 GlobalSession.CaptureEquipmentInventoryState(this);
             }
+            else if (IsPotionContainer())
+            {
+                Debug.Log($"[Inventory] CAPTURING Potion state for '{gameObject.name}' into GameSession snapshot.");
+                GlobalSession.CapturePotionInventoryState(this);
+            }
         }
 
         private bool IsPlayerBackpackContainer()
@@ -359,6 +377,12 @@ namespace OutlandHaven.Inventory
             return ContainerBlueprint != null
                    && ContainerBlueprint.AssociatedView == ScreenType.Inventory
                    && !ContainerBlueprint.IsEquipment;
+        }
+
+        private bool IsPotionContainer()
+        {
+            return ContainerBlueprint != null
+                   && ContainerBlueprint.AssociatedView == ScreenType.Potions;
         }
 
         private bool LooksLikeEquipmentContainer()

--- a/Toris/Assets/Scripts/Save System/GameSaveData.cs
+++ b/Toris/Assets/Scripts/Save System/GameSaveData.cs
@@ -21,7 +21,8 @@ namespace OutlandHaven.SaveSystem
 
         // Inventories
         public SavedInventoryData PlayerBackpack;
-        public SavedInventoryData PlayerEquipment; // MISSING ADDITION
+        public SavedInventoryData PlayerEquipment;
+        public SavedInventoryData PlayerPotion;
 
         // Quest bridge: Pixel Crushers serializes quest states, quest entries, and Lua variables into this blob.
         // Future menu save-slot loads may deserialize this before MainArea/Dialogue Manager exists, so GameSessionSO defers applying it through the quest save bridge.

--- a/Toris/Assets/Scripts/UIToolkit/Documentation/Changelog/CHANGELOG.md
+++ b/Toris/Assets/Scripts/UIToolkit/Documentation/Changelog/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Current/Recent] - Fix Potion and Equipment Inventory Scene Loading
+* **Persistent Inventory Snapshots:** Refactored `GameSessionSO` to prevent clearing inventory snapshots after they are applied. This ensures inventory data remains available across multiple scene transitions and re-instantiations.
+* **Potion Inventory Integration:** Added full support for the Potion inventory to the scene transition and save systems.
+    * **Session Tracking:** Added `PlayerPotionInventory` and `_potionInventorySnapshot` to `GameSessionSO`.
+    * **Capture/Restore:** Implemented `CapturePotionInventoryState` and `TryApplyPotionInventoryState` in `GameSessionSO`.
+    * **Manager Binding:** Updated `InventoryManager` to automatically register and restore potion inventory state via `ScreenType.Potions` association.
+    * **Persistence:** Added `PlayerPotion` to `GameSaveData` and updated export/import logic in `GameSessionSO` to include potion data.
+
 ## [Current/Recent] - Potion Hotkey Integration
 * **Hotkey Consumption:** Implemented hotkey-driven potion consumption ('1' and '2') by wiring `PlayerInputReaderSO` to `InventoryActionController`, allowing direct item usage from the Potion quickbar slots.
 * **Resolution Resolver:** Added `ResolvePotionInventory` to `PlayerInventorySceneResolver` to ensure correct runtime reference handling for potion containers during controller initialization.

--- a/Toris/Assets/Scripts/UIToolkit/ScriptableObjects/GameSessionSO.cs
+++ b/Toris/Assets/Scripts/UIToolkit/ScriptableObjects/GameSessionSO.cs
@@ -29,6 +29,8 @@ namespace OutlandHaven.UIToolkit
         public InventoryManager PlayerInventory;
         [System.NonSerialized]
         public InventoryManager PlayerEquipment;
+        [System.NonSerialized]
+        public InventoryManager PlayerPotionInventory;
 
         [Header("Global Anchors")]
         public PlayerProgressionAnchorSO ProgressionAnchor;
@@ -36,6 +38,7 @@ namespace OutlandHaven.UIToolkit
 
         [System.NonSerialized] private RuntimeInventorySnapshot _playerInventorySnapshot;
         [System.NonSerialized] private RuntimeInventorySnapshot _equipmentInventorySnapshot;
+        [System.NonSerialized] private RuntimeInventorySnapshot _potionInventorySnapshot;
         [System.NonSerialized] private RuntimeProgressionSnapshot _playerProgressionSnapshot;
         [System.NonSerialized] private RuntimeStatsSnapshot _playerStatsSnapshot;
         [System.NonSerialized] private PlayerAbilitySO[] _playerAbilitySlotSnapshot;
@@ -63,8 +66,10 @@ namespace OutlandHaven.UIToolkit
         {
             PlayerInventory = null;
             PlayerEquipment = null;
+            PlayerPotionInventory = null;
             _playerInventorySnapshot = null;
             _equipmentInventorySnapshot = null;
+            _potionInventorySnapshot = null;
             _playerProgressionSnapshot = null;
             _playerStatsSnapshot = null;
             _playerAbilitySlotSnapshot = null;
@@ -72,6 +77,7 @@ namespace OutlandHaven.UIToolkit
 
         public RuntimeInventorySnapshot GetPlayerInventorySnapshot() => _playerInventorySnapshot;
         public RuntimeInventorySnapshot GetEquipmentInventorySnapshot() => _equipmentInventorySnapshot;
+        public RuntimeInventorySnapshot GetPotionInventorySnapshot() => _potionInventorySnapshot;
 
         public void CapturePlayerInventoryState(InventoryManager inventoryManager)
         {
@@ -89,7 +95,6 @@ namespace OutlandHaven.UIToolkit
                 return false;
 
             _playerInventorySnapshot.ApplyTo(inventoryManager);
-            _playerInventorySnapshot = null;
             return true;
         }
 
@@ -109,7 +114,25 @@ namespace OutlandHaven.UIToolkit
                 return false;
 
             _equipmentInventorySnapshot.ApplyTo(inventoryManager);
-            _equipmentInventorySnapshot = null;
+            return true;
+        }
+
+        public void CapturePotionInventoryState(InventoryManager inventoryManager)
+        {
+            _potionInventorySnapshot = RuntimeInventorySnapshot.Create(inventoryManager);
+        }
+
+        public void CapturePotionInventoryState(SavedInventoryData data, ItemDatabaseSO database)
+        {
+            _potionInventorySnapshot = RuntimeInventorySnapshot.CreateFromSavedData(data, database);
+        }
+
+        public bool TryApplyPotionInventoryState(InventoryManager inventoryManager)
+        {
+            if (_potionInventorySnapshot == null)
+                return false;
+
+            _potionInventorySnapshot.ApplyTo(inventoryManager);
             return true;
         }
 
@@ -278,6 +301,7 @@ namespace OutlandHaven.UIToolkit
             // --- 3. EXPORT INVENTORIES ---
             saveData.PlayerBackpack = ExtractInventoryData(PlayerInventory);
             saveData.PlayerEquipment = ExtractInventoryData(PlayerEquipment);
+            saveData.PlayerPotion = ExtractInventoryData(PlayerPotionInventory);
 
             // Quest bridge: keep Toris as the save-file owner while Pixel Crushers owns dialogue/quest state.
             saveData.PixelCrushersDialogueSaveData = global::PixelCrushersDialogueSaveBridge.CaptureSaveData();
@@ -323,6 +347,14 @@ namespace OutlandHaven.UIToolkit
                     RestoreInventoryData(PlayerEquipment, saveData.PlayerEquipment, itemDatabase);
                 else
                     CaptureEquipmentInventoryState(saveData.PlayerEquipment, itemDatabase);
+            }
+
+            if (saveData.PlayerPotion != null)
+            {
+                if (PlayerPotionInventory != null)
+                    RestoreInventoryData(PlayerPotionInventory, saveData.PlayerPotion, itemDatabase);
+                else
+                    CapturePotionInventoryState(saveData.PlayerPotion, itemDatabase);
             }
 
             // Quest bridge: future menu save-slot loads may import before MainArea/Dialogue Manager exists.


### PR DESCRIPTION
This PR fixes a bug where the potion and equipment inventories failed to load correctly when transitioning between scenes. 

The primary cause was that `GameSessionSO` cleared its internal snapshots immediately after they were applied to an `InventoryManager`. In a multi-scene environment, this meant subsequent scenes or re-instantiations of the inventory would find empty snapshots. By removing the clearing logic, snapshots now persist for the duration of the session until overwritten by a new capture.

Additionally, the Potion inventory was missing from the scene transfer and save systems. This PR integrates the Potion inventory into `GameSessionSO` and `InventoryManager`, and ensures it is correctly serialized in `GameSaveData`.

---
*PR created automatically by Jules for task [1769384856862766833](https://jules.google.com/task/1769384856862766833) started by @sourcereris*